### PR TITLE
Retain submission form data when submitting with empty user input fields

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -39,7 +39,11 @@ class SubmissionsController < ApplicationController
         success: t('.success_message')
       }
     else
-      redirect_to new_milestone_team_submission_path(milestone, team), flash: {
+      render :new, locals: {
+        team_id: params[:team_id],
+        milestone: milestone,
+        submissions: Submission.where(team_id: team.id)
+      }, flash: {
         danger: t('.failure_message',
                   error_message: @submission.errors.full_messages.join(', '))
       }
@@ -78,10 +82,11 @@ class SubmissionsController < ApplicationController
         success: t('.success_message')
       }
     else
-      edit_submission_path = edit_milestone_team_submission_path(milestone,
-                                                                 team,
-                                                                 @submission)
-      redirect_to edit_submission_path, flash: {
+      render :edit, locals: {
+        team_id: params[:team_id],
+        milestone: milestone,
+        submissions: Submission.where(team_id: team.id)
+      }, flash: {
         danger: t('.failure_message',
                   error_message: @submission.errors.full_messages.join(', '))
       }

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -38,12 +38,14 @@ class SubmissionsController < ApplicationController
       redirect_to home_path, flash: {
         success: t('.success_message')
       }
-    else
+    elsif empty_input_field?
       render :new, locals: {
         team_id: params[:team_id],
         milestone: milestone,
         submissions: Submission.where(team_id: team.id)
-      }, flash: {
+      }
+    else
+      redirect_to new_milestone_team_submission_path(milestone, team), flash: {
         danger: t('.failure_message',
                   error_message: @submission.errors.full_messages.join(', '))
       }
@@ -81,12 +83,17 @@ class SubmissionsController < ApplicationController
       redirect_to home_path, flash: {
         success: t('.success_message')
       }
-    else
+    elsif empty_input_field?
       render :edit, locals: {
         team_id: params[:team_id],
         milestone: milestone,
         submissions: Submission.where(team_id: team.id)
-      }, flash: {
+      }
+    else
+      edit_submission_path = edit_milestone_team_submission_path(milestone,
+                                                                 team,
+                                                                 @submission)
+      redirect_to edit_submission_path, flash: {
         danger: t('.failure_message',
                   error_message: @submission.errors.full_messages.join(', '))
       }
@@ -100,6 +107,12 @@ class SubmissionsController < ApplicationController
     sub_params[:milestone_id] = @submission.milestone_id
     sub_params[:team_id] = @submission.team_id
     @submission.update(sub_params) ? @submission : nil
+  end
+
+  def empty_input_field?
+    @submission.errors[:project_log].any? || 
+    @submission.errors[:read_me].any? || 
+    @submission.errors[:video_link].any?
   end
 
   def submission_params


### PR DESCRIPTION
Fixes #476 

Upon failed submission due to empty user input field(s), render page instead of redirecting