### PR TITLE
Evaluation ratings related bugs

### DIFF
--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -171,7 +171,7 @@ class Team < ActiveRecord::Base
     peer_evaluations_hash.each do |milestone_id, evaluations_hash|
       ratings = []
       evaluations_hash.each do |key, evaluation|
-        if !evaluation.nil?
+        if !evaluation.nil? && !evaluation.private_content.nil?
           private_parts = JSON.parse(evaluation.private_content)
           rating = private_parts[Milestone.find(
             milestone_id).get_overall_rating_question_id].to_i


### PR DESCRIPTION
#460 and #461 is fixed easily by adding in a nil check for evaluation.private_content
Might be due to evaluators not giving a rating to the team yet/dropped orbital?
However I am not sure of the proper format of creating a evaluation template with rating score style questions to test if the rating calculation feature still works.