### PR TITLE
Add link into Nav bar and check for matric number validity

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -192,7 +192,7 @@ class UsersController < ApplicationController
   def user_params(generate_pswd = false)
     user_ps = params.require(:user).permit(
       :user_name, :email, :uid, :provider, :slack_id, :github_link, :linkedin_link,
-      :blog_link, :program_of_study, :self_introduction)
+      :blog_link, :program_of_study, :matric_number, :self_introduction)
     user_ps[:password] = Devise.friendly_token.first(8) if generate_pswd
     user_ps[:provider] = user_ps[:provider].to_i
     user_ps[:program_of_study] = user_ps[:program_of_study].to_i

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -26,12 +26,10 @@ class User < ActiveRecord::Base
     scope: :provider,
     message: ': An OpenID account can only be used for creating one account'
   }, if: 'uid.present?'
-  #check for matric number
-  validates :matric_number, presence: true, format: {
-    with: /\AA\d{7}\D\z/i,
+  validates :matric_number, format: {
+    with: /\A$|\AA\d{7}\D\z/i,
     message: ': Invalid matric number'
   }
-
   has_many :registrations, dependent: :destroy
 
   enum provider: [:provider_nil, :provider_NUS]

--- a/app/views/shared/nav_headers/_admin_nav_header_list.html.erb
+++ b/app/views/shared/nav_headers/_admin_nav_header_list.html.erb
@@ -1,5 +1,7 @@
 <ul class="nav navbar-nav">
   <li><a href="<%= home_path %>">Home</a></li>
+  <li><a href="<%= public_views_public_staff_index_path %>">Staff</a></li>
+  <li><a href="<%= public_views_public_projects_path %>">Projects</a></li>
   <li class="dropdown">
     <a href="#" class="dropdown-toggle" data-toggle="dropdown" role="button" aria-haspopup="true" aria-expanded="false">Users and roles <span class="caret"></span></a>
     <ul class="dropdown-menu">

--- a/app/views/shared/nav_headers/_adviser_nav_header_list.html.erb
+++ b/app/views/shared/nav_headers/_adviser_nav_header_list.html.erb
@@ -1,5 +1,7 @@
 <ul class="nav navbar-nav">
   <li><a href="<%= home_path %>">Home</a></li>
+  <li><a href="<%= public_views_public_staff_index_path %>">Staff</a></li>
+  <li><a href="<%= public_views_public_projects_path %>">Projects</a></li>
   <li><a href="<%= students_path %>">Students</a></li>
   <li><a href="<%= teams_path %>">Teams</a></li>
   <li><a href="<%= evaluatings_path %>">Evaluating relations</a></li>

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -5,8 +5,7 @@ Devise.setup do |config|
   # random tokens. Changing this key will render invalid all existing
   # confirmation, reset password and unlock tokens in the database.
   config.secret_key = ENV['DEVISE_SECRET_TOKEN']
-  config.secret_key = '34a7a38f6ecd94ef986cfb9dbe01a2ab62b8440fbd02b54f0325ced692674c3cca68b7433b963973b1c85be0746d8e2e711b86ed95335f1a7a2aaa49b11fa652'
-
+  
   # ==> Mailer Configuration
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class

--- a/config/secrets.yml.travis
+++ b/config/secrets.yml.travis
@@ -1,8 +1,8 @@
 development:
-  secret_key_base: 63f2a15d2feac9461a93853cec76a795cda93cbcaa943b9eeb568e970dd8ed5096494d56fa1e6eec09921c09e9ab8f1397baa0c71c954f93d4fd10193bcb970e
+  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
 
 test:
-  secret_key_base: 9c169c5bf92c31fb43be934dd0d4025dc7797653f555c6de8381fc38d33a1c98e3b7d011dd76caea265b1cc82eb76b96e9f00560864bced82f1bd910437eb3b3
+  secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>
 
 production:
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>


### PR DESCRIPTION
1. Add a link in the nav bar for for admins and advisors as the other user types use the general nav header.

2. Update the user fields to add Matric Number and Home Faculty fields. 
Implement a validation check for Matric Numbers. 
Matric number can be left blank for mentors etc.