### PR TITLE
Fix notifications (#520, #521)

### DIFF
--- a/config/initializers/thredded.rb
+++ b/config/initializers/thredded.rb
@@ -57,10 +57,10 @@ Thredded.messageboards_order = :position
 
 # ==> Email Configuration
 # Email "From:" field will use the following
-# Thredded.email_from = 'no-reply@example.com'
+Thredded.email_from = 'no-reply@comp.nus.edu.sg'
 
 # Emails going out will prefix the "Subject:" with the following string
-# Thredded.email_outgoing_prefix = '[My Forum] '
+Thredded.email_outgoing_prefix = '[Skylab Forum] '
 
 # ==> View Configuration
 # Set the layout for rendering the thredded views.

--- a/db/migrate/20170307170913_add_index_to_username_in_users_for_thredded.rb
+++ b/db/migrate/20170307170913_add_index_to_username_in_users_for_thredded.rb
@@ -1,0 +1,5 @@
+class AddIndexToUsernameInUsersForThredded < ActiveRecord::Migration
+  def change
+  	DbTextSearch::CaseInsensitive.add_index(connection, Thredded.user_class.table_name, Thredded.user_name_column, unique: true)
+  end
+end

--- a/db/migrate/20170307175911_remove_moderation_functionality.rb
+++ b/db/migrate/20170307175911_remove_moderation_functionality.rb
@@ -1,0 +1,5 @@
+class RemoveModerationFunctionality < ActiveRecord::Migration
+  def change
+  	change_column_default :thredded_user_details, :moderation_state, 1 # approved
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170113012842) do
+ActiveRecord::Schema.define(version: 20170307175911) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -386,7 +386,7 @@ ActiveRecord::Schema.define(version: 20170113012842) do
     t.integer  "posts_count",                 default: 0
     t.integer  "topics_count",                default: 0
     t.datetime "last_seen_at"
-    t.integer  "moderation_state",            default: 0, null: false
+    t.integer  "moderation_state",            default: 1, null: false
     t.datetime "moderation_state_changed_at"
     t.datetime "created_at",                              null: false
     t.datetime "updated_at",                              null: false


### PR DESCRIPTION
_Discussion here distills instructions from preceding comments in PRs and issues_

Note: Before performing the merge, check whether the following line in `config/initializers/thredded.rb` matches this:
> ```
>12: Thredded.user_name_column = :user_name
>```

If not, perform a `git pull` from master and ignore the conflict in this file only.

---
And then, or otherwise: 

### #520 may need more tweaking as user cannot be found with @-mention. 

To overcome this, reference the user's id `@1`, for example.

### #521 (priority). Fixes email notifications of mentions and new posts. 

Currently, an error message is posted upon hitting the post button, which would be because of this:

`A copy of XX has been removed from the module tree but is still active!`

It should be solved with restarting the rails app **after merging this PR**. Basically the app was not restarted during the last `git pull`, where Thredded was first introduced. **Anytime we make changes to `config/initializers/thredded.rb`, we have to restart the rails app.**

I also noticed that only upon moderator approval, the notification email will be sent out. I have since disabled moderation. Still, can't get emails to be sent through my local system (possibly no external internet access for the module here) but hopefully it will be fine on our server. 

Would be good to publish the logs containing the following lines for debugging—it should look like this after a **mention** is made.

```
[ActiveJob] [Thredded::AutoFollowAndNotifyJob] [c03d8e07-effc-4a67-9f63-cfe81ed3f206]   CACHE (0.0ms)  SELECT "users".* FROM "users" WHERE (LOWER("users"."user_name") IN (LOWER('Justin Ng Jin Yiu')))
[ActiveJob] [Thredded::AutoFollowAndNotifyJob] [c03d8e07-effc-4a67-9f63-cfe81ed3f206]   Rendered /Users/justin/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/thredded-0.9.4/app/views/thredded/post_mailer/post_notification.html.erb (25.2ms)
[ActiveJob] [Thredded::AutoFollowAndNotifyJob] [c03d8e07-effc-4a67-9f63-cfe81ed3f206]   Rendered /Users/justin/.rbenv/versions/2.3.0/lib/ruby/gems/2.3.0/gems/thredded-0.9.4/app/views/thredded/post_mailer/post_notification.text.erb (0.5ms)
[ActiveJob] [Thredded::AutoFollowAndNotifyJob] [c03d8e07-effc-4a67-9f63-cfe81ed3f206]
Thredded::PostMailer#post_notification: processed outbound mail in 115.8ms
[ActiveJob] [Thredded::AutoFollowAndNotifyJob] [c03d8e07-effc-4a67-9f63-cfe81ed3f206]
Sent mail to no-reply@comp.nus.edu.sg (908.2ms)
[ActiveJob] [Thredded::AutoFollowAndNotifyJob] [c03d8e07-effc-4a67-9f63-cfe81ed3f206] Date: Wed, 08 Mar 2017 02:00:53 +0800
From: no-reply@comp.nus.edu.sg
To: no-reply@comp.nus.edu.sg
Message-ID: <58bef55548e49_a3543ffea77029d079094@JNW-MBP.local.mail>
Subject: [Skylab Forum] Test sticky topic
Mime-Version: 1.0
Content-Type: multipart/alternative;
 boundary="--==_mimepart_58bef5554762e_a3543ffea77029d07898c";
 charset=UTF-8
Content-Transfer-Encoding: 7bit
X-SMTPAPI: {"category": ["thredded_General Stuff","post_notification"]}

----==_mimepart_58bef5554762e_a3543ffea77029d07898c
Content-Type: text/plain;
 charset=UTF-8
Content-Transfer-Encoding: 7bit

I know @"Justin Ng Jin Yiu"

---

This email was sent to you because you are following this topic
"Test sticky topic". Go here to view the conversation:
http://localhost:3000/forum/posts/11

To unsubscribe from these emails, update your preferences here:
  http://localhost:3000/forum/general-stuff/preferences/edit

----==_mimepart_58bef5554762e_a3543ffea77029d07898c
Content-Type: text/html;
 charset=UTF-8
Content-Transfer-Encoding: 7bit

<blockquote><p>I know <a href="/users/1">@"Justin Ng Jin Yiu"</a></p></blockquote>

<hr />

<p>
  This email was sent to you because you are following this topic
  "<a href="http://localhost:3000/forum/posts/11">Test sticky topic</a>".
  <a href="http://localhost:3000/forum/general-stuff/test-sticky-topic">View the conversation here</a>.
</p>

<p>
  To unsubscribe from these emails, update your
  <a href="http://localhost:3000/forum/general-stuff/preferences/edit">preferences</a>.
</p>

----==_mimepart_58bef5554762e_a3543ffea77029d07898c--
```

Lastly, would be great if we could communicate via Slack, if there is one for Orbital 2017. Makes comms less messy and easier to track :-) 

After this fix, the forum should have its basic functionality, sans private messaging. In time to come we have to upgrade the engine to the latest version, that could possibly fix some of the bugs we are seeing.

Cheers, thanks!