### PR TITLE
Allow all registered users to access forums (#522)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -56,7 +56,7 @@ class ApplicationController < ActionController::Base
   end
 
   def current_user_public?()
-    return !(current_user_student? || current_user_adviser? || current_user_admin? || current_user_mentor?)
+    return current_user.nil?
   end
 
   def current_user_student?(cohort = nil)

--- a/config/initializers/thredded.rb
+++ b/config/initializers/thredded.rb
@@ -130,7 +130,7 @@ Thredded.autocomplete_min_length = 2 # lower to 1 if have 1-letter names -- incr
 # Change how users can choose to be notified, by adding notifiers here, or removing the initializer altogether
 #
 # default:
-Thredded.notifiers = [Thredded::EmailNotifier.new]
+#Thredded.notifiers = [Thredded::EmailNotifier.new]
 #
 # none:
 # Thredded.notifiers = []


### PR DESCRIPTION
- Registered users (including pending students) can now access the forum. (fixed #522)
- Disabled email notification system until sendgrid issue is looked into. Users no longer face the RSOD when they hit reply/post. (NOTE: Private messaging still does not work)

Remember to restart rails since `thredded.rb` was modified.

Cheers ~