### PR TITLE
Remove db:migration files that are causing migration errors.

### DIFF
--- a/db/migrate/20170307170913_add_index_to_username_in_users_for_thredded.rb
+++ b/db/migrate/20170307170913_add_index_to_username_in_users_for_thredded.rb
@@ -1,5 +1,0 @@
-class AddIndexToUsernameInUsersForThredded < ActiveRecord::Migration
-  def change
-  	DbTextSearch::CaseInsensitive.add_index(connection, Thredded.user_class.table_name, Thredded.user_name_column, unique: true)
-  end
-end

--- a/db/migrate/20170307175911_remove_moderation_functionality.rb
+++ b/db/migrate/20170307175911_remove_moderation_functionality.rb
@@ -1,5 +1,0 @@
-class RemoveModerationFunctionality < ActiveRecord::Migration
-  def change
-  	change_column_default :thredded_user_details, :moderation_state, 1 # approved
-  end
-end


### PR DESCRIPTION
Issued due to errors from #530 and #526.

These migrations fail to run on our existing database. This is because 

1) our users table already has an index 
2) there exist duplicate names in the db, so unique index cannot be generated.

To fix this we will first remove these two migration files. No need to rollback because the migration failed in the first place (correct me if I am wrong) and nothing happened to the db. After pulling it would be prudent to perform a rollback: 

```
(bundle exec) rake db:migrate:down VERSION=20161230033247
(bundle exec) rake db:migrate
```

Thanks!