### PR TITLE
Fix forum notifications, part 2

### DIFF
--- a/config/initializers/thredded.rb
+++ b/config/initializers/thredded.rb
@@ -60,7 +60,7 @@ Thredded.messageboards_order = :position
 #Thredded.email_from = 'no-reply@comp.nus.edu.sg'
 
 # Emails going out will prefix the "Subject:" with the following string
-Thredded.email_outgoing_prefix = '[Skylab Forum] '
+# Thredded.email_outgoing_prefix = '[Skylab Forum] '
 
 # ==> View Configuration
 # Set the layout for rendering the thredded views.
@@ -130,16 +130,16 @@ Thredded.autocomplete_min_length = 2 # lower to 1 if have 1-letter names -- incr
 # Change how users can choose to be notified, by adding notifiers here, or removing the initializer altogether
 #
 # default:
-#Thredded.notifiers = [Thredded::EmailNotifier.new]
+# Thredded.notifiers = [Thredded::EmailNotifier.new]
 #
 # none:
-# Thredded.notifiers = []
+Thredded.notifiers = []
 #
 # add in (must install separate gem (under development) as well):
 # Thredded.notifiers = [Thredded::EmailNotifier.new, Thredded::PushoverNotifier.new(ENV['PUSHOVER_APP_ID'])]
 
 
-# to allow you to not to have to add `main_app` before every path helper 
+# to allow you to not to have to add `main_app` before every path helper
 # when embedding Thredded within a main-app supplied layout (with navbar and links to the main_app)
 
 Rails.application.config.to_prepare do

--- a/config/initializers/thredded.rb
+++ b/config/initializers/thredded.rb
@@ -114,11 +114,11 @@ Thredded.autocomplete_min_length = 2 # lower to 1 if have 1-letter names -- incr
 #
 # By default, a user will be subscribed to a topic they've created. Uncomment this to not subscribe them:
 #
-# Thredded.auto_follow_when_creating_topic = false
+Thredded.auto_follow_when_creating_topic = false
 #
 # By default, a user will be subscribed to (follow) a topic they post in. Uncomment this to not subscribe them:
 #
-# Thredded.auto_follow_when_posting_in_topic = false
+Thredded.auto_follow_when_posting_in_topic = false
 #
 # By default, a user will be subscribed to the topic they get @-mentioned in.
 # Individual users can disable this in the Notification Settings.

--- a/config/initializers/thredded.rb
+++ b/config/initializers/thredded.rb
@@ -130,10 +130,10 @@ Thredded.auto_follow_when_posting_in_topic = false
 # Change how users can choose to be notified, by adding notifiers here, or removing the initializer altogether
 #
 # default:
-# Thredded.notifiers = [Thredded::EmailNotifier.new]
+Thredded.notifiers = [Thredded::EmailNotifier.new]
 #
 # none:
-Thredded.notifiers = []
+# Thredded.notifiers = []
 #
 # add in (must install separate gem (under development) as well):
 # Thredded.notifiers = [Thredded::EmailNotifier.new, Thredded::PushoverNotifier.new(ENV['PUSHOVER_APP_ID'])]

--- a/config/initializers/thredded.rb
+++ b/config/initializers/thredded.rb
@@ -57,10 +57,10 @@ Thredded.messageboards_order = :position
 
 # ==> Email Configuration
 # Email "From:" field will use the following
-# Thredded.email_from = 'no-reply@example.com'
+Thredded.email_from = 'no-reply@comp.nus.edu.sg'
 
 # Emails going out will prefix the "Subject:" with the following string
-# Thredded.email_outgoing_prefix = '[My Forum] '
+Thredded.email_outgoing_prefix = '[Skylab Forum] '
 
 # ==> View Configuration
 # Set the layout for rendering the thredded views.

--- a/config/initializers/thredded.rb
+++ b/config/initializers/thredded.rb
@@ -57,10 +57,10 @@ Thredded.messageboards_order = :position
 
 # ==> Email Configuration
 # Email "From:" field will use the following
-#Thredded.email_from = 'no-reply@comp.nus.edu.sg'
+Thredded.email_from = 'nusskylab@gmail.com'
 
 # Emails going out will prefix the "Subject:" with the following string
-# Thredded.email_outgoing_prefix = '[Skylab Forum] '
+Thredded.email_outgoing_prefix = '[Skylab Forum] '
 
 # ==> View Configuration
 # Set the layout for rendering the thredded views.

--- a/config/initializers/thredded.rb
+++ b/config/initializers/thredded.rb
@@ -57,7 +57,7 @@ Thredded.messageboards_order = :position
 
 # ==> Email Configuration
 # Email "From:" field will use the following
-Thredded.email_from = 'no-reply@comp.nus.edu.sg'
+#Thredded.email_from = 'no-reply@comp.nus.edu.sg'
 
 # Emails going out will prefix the "Subject:" with the following string
 Thredded.email_outgoing_prefix = '[Skylab Forum] '

--- a/db/migrate/20170307170913_add_index_to_username_in_users_for_thredded.rb
+++ b/db/migrate/20170307170913_add_index_to_username_in_users_for_thredded.rb
@@ -1,0 +1,5 @@
+class AddIndexToUsernameInUsersForThredded < ActiveRecord::Migration
+  def change
+  	DbTextSearch::CaseInsensitive.add_index(connection, Thredded.user_class.table_name, Thredded.user_name_column, unique: true)
+  end
+end

--- a/db/migrate/20170307175911_remove_moderation_functionality.rb
+++ b/db/migrate/20170307175911_remove_moderation_functionality.rb
@@ -1,0 +1,5 @@
+class RemoveModerationFunctionality < ActiveRecord::Migration
+  def change
+  	change_column_default :thredded_user_details, :moderation_state, 1 # approved
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20170113012842) do
+ActiveRecord::Schema.define(version: 20170307175911) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -386,7 +386,7 @@ ActiveRecord::Schema.define(version: 20170113012842) do
     t.integer  "posts_count",                 default: 0
     t.integer  "topics_count",                default: 0
     t.datetime "last_seen_at"
-    t.integer  "moderation_state",            default: 0, null: false
+    t.integer  "moderation_state",            default: 1, null: false
     t.datetime "moderation_state_changed_at"
     t.datetime "created_at",                              null: false
     t.datetime "updated_at",                              null: false


### PR DESCRIPTION
This PR does the following

- Reactivate notification system, but with
- From email parameters and
- Subject header email parameters set
- Force off auto follow of topics and posts, because that is the nature of the error.

If this fails we will post up our issue to the Thredded issue tracker and see how it goes. Thanks!