### PR TITLE
Enable line breaks for peer evaluation response viewing.

### DIFF
--- a/app/views/questions/_text_question.html.erb
+++ b/app/views/questions/_text_question.html.erb
@@ -6,7 +6,7 @@
         </div>
         <div class="panel-body">
           <div class="help-block"><%= locals[:question].instruction.nil? ? '' : locals[:question].instruction.html_safe %></div>
-          <div class="form-control-static"><%= locals[:question_response] %></div>
+          <textarea class="form-control" readonly="true"><%= locals[:question_response] %></textarea>
         </div>
       </div>
     </div>


### PR DESCRIPTION
Addresses #548.

In `app/views/questions/_text_question.html.erb`, I have changed `<div class="form-control-static" ...` to `<textarea class="form-control" readonly="true" ... ` to enable line breaks.

This implies that **all** answers to text questions in view mode (e.g. View Peer Evaluation, View Submission) are rendered as read-only text boxes, which preserves line breaks. Note that text questions do not support formatting.

<img width="1184" alt="screen shot 2017-06-01 at 11 38 46 pm" src="https://cloud.githubusercontent.com/assets/10694375/26687842/7cc38e42-4723-11e7-822c-abbe065e0920.png">
