### PR TITLE
Fix: remove margins in main footer element

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -83,6 +83,10 @@ $thredded-button-font-size: 1.25rem;
   min-height: 100vh;
 }
 
+#main-footer {
+  margin: 0;
+}
+
 #error_explanation {
   color: #f00;
   ul {

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -32,7 +32,7 @@
     <%= content_for?(:main_content) ? yield(:main_content) : yield %>
     <a href="javascript:" id="return-to-top"><i class="glyphicon glyphicon-chevron-up"></i></a>
   </div>
-  <footer class="col-lg-12 footer text-muted">
+  <footer class="col-lg-12 footer text-muted" id="main-footer">
     <div class="container">
       <p class="col-sm-4 text-center">&copy;NUS SoC</p>
       <p class="col-sm-4 text-center">Orbital Program</p>


### PR DESCRIPTION
Fixes #574

Fixes this issue by setting `margin` property to 0 only for the main footer element.
