### PR TITLE
Fix: show an invite button to registered students without teams

### DIFF
--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -84,7 +84,6 @@ class UsersController < ApplicationController
     return redirect_to user_path(@user.id), flash: {
       danger: t('.register_as_student_message')
     } unless student
-    return redirect_to student_path(student) unless student.is_pending
     student_team = student.team || Team.new
     @page_title = t('.page_title')
     render locals: {
@@ -107,14 +106,14 @@ class UsersController < ApplicationController
     invited_student = Student.student?(invited_user.id, cohort: current_cohort)
     return redirect_to user_path(@user.id), flash: {
       danger: t('.no_registered_student_found_message')
-    } if !invited_student || !invited_student.is_pending
+    } if !invited_student
     return redirect_to user_path(@user.id), flash: {
       danger: t('.student_found_team_message')
     } if invited_student.team
     invitor_student = Student.student?(@user.id, cohort: current_cohort)
     return redirect_to user_path(@user.id), flash: {
       danger: t('.cannot_register_team_message')
-    } if !invitor_student || !invitor_student.is_pending || invitor_student.team
+    } if !invitor_student || invitor_student.team
     team = Team.new(
       team_name: (Team.order('id').last.id + 1), is_pending: true,
       cohort: current_cohort, invitor_student_id: invitor_student.id)

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -134,7 +134,7 @@ class UsersController < ApplicationController
     student_user = Student.student?(@user.id, cohort: current_cohort)
     return redirect_to user_path(@user.id), flash: {
       danger: t('.cannot_confirm_team_message')
-    } if !student_user || !student_user.is_pending || !student_user.team
+    } if !student_user || !student_user.team
     team = student_user.team
     if team_params[:confirm] == 'true'
       team.is_pending = false

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -224,7 +224,7 @@ RSpec.describe UsersController, type: :controller do
 
         student = FactoryGirl.create(:student, user: subject.current_user, is_pending: false)
         get :register_as_team, id: subject.current_user.id
-        expect(response).to redirect_to(student_path(student))
+        expect(response).to render_template(:register_as_team)
 
         student.is_pending = true
         student.save


### PR DESCRIPTION
Addresses missing backend logic for #554. While buttons do link up correctly from that PR, the controller currently does not allow confirmed students to use those links.