### PR TITLE
Allow mentors to view the team profiles of teams assigned to them

### DIFF
--- a/app/views/mentors/_mentor_view.html.erb
+++ b/app/views/mentors/_mentor_view.html.erb
@@ -4,54 +4,79 @@
       <span><%= locals[:mentor].user.user_name %></span>
     </h2>
   </div>
-  <div class="panel-body">
-    <% locals[:milestones].each do |milestone| %>
-      <h3 class="text-center"><%= milestone.name %></h3>
-      <div class="table-responsive">
-        <table class="table">
-          <thead>
-            <tr><th>Team Name</th><th>Status</th><th>Last updated at</th></tr>
-          </thead>
-          <tbody>
-            <% locals[:mentor].teams.each do |team| %>
-              <% if (team_submission = locals[:teams_submissions][milestone.id][team.id]) %>
-                <tr>
-                  <td><%= team.team_name %></td>
-                  <td>
-                    <a href="<%= milestone_team_submission_path(milestone.id, team.id, team_submission.id) %>"
-                       class="btn btn-success">
-                      View
-                    </a>
-                  </td>
-                  <td>
-                    <%= l team_submission.updated_at %>
-                  </td>
-                </tr>
-              <% else %>
-                <tr>
-                  <td>
-                    <span data-toggle="tooltip" data-placement="top" title="The team has not submitted project log yet">
-                      <%= team.team_name %>
-                    </span>
-                  </td>
-                  <td>
-                    <a href="#" class="btn btn-default" disabled="disabled">
-                      View
-                    </a>
-                  </td>
-                  <td>
-                    Not submitted yet
-                  </td>
-                </tr>
-              <% end %>
-            <% end %>
-            <% if locals[:mentor].teams.length <= 0 %>
-              <tr><td colspan="3">No teams to display yet</td></tr>
-            <% end %>
-          </tbody>
-        </table>
+  <div class = "panel-body">
+    <div role="tabpanel">
+      <ul class="nav nav-tabs" role="tablist">
+        <li role="presentation" class="active">
+          <a href="#teams-panel" aria-controls="teams-panel"
+            role="tab" data-toggle="tab">
+            View all your teams
+          </a>
+        </li>
+        <li role="presentation">
+          <a href="#milestones-panel" aria-controls="milestones-panel"
+            role="tab" data-toggle="tab">
+            View milestones submitted by teams
+          </a>
+        </li>
+      </ul>
+      <div class="tab-content">
+        <div role="tabpanel" class="tab-pane fade in active" id="teams-panel">
+          <h2 class="text-center">Teams</h2>
+            <%= render 'mentors_teams', locals: {mentor: @role} %>
+        </div>
+        <div role="tabpanel" class="tab-pane fade" id="milestones-panel">
+          <h2 class="text-center">Teams</h2>
+          <% locals[:milestones].each do |milestone| %>
+          <h3 class="text-center"><%= milestone.name %></h3>
+          <div class="table-responsive">
+            <table class="table">
+              <thead>
+                <tr><th>Team Name</th><th>Status</th><th>Last updated at</th></tr>
+              </thead>
+                <tbody>
+                  <% locals[:mentor].teams.each do |team| %>
+                    <% if (team_submission = locals[:teams_submissions][milestone.id][team.id]) %>
+                      <tr>
+                        <td><%= team.team_name %></td>
+                        <td>
+                          <a href="<%= milestone_team_submission_path(milestone.id, team.id, team_submission.id) %>"
+                             class="btn btn-success">
+                            View
+                          </a>
+                        </td>
+                        <td>
+                          <%= l team_submission.updated_at %>
+                        </td>
+                      </tr>
+                    <% else %>
+                      <tr>
+                        <td>
+                          <span data-toggle="tooltip" data-placement="top" title="The team has not submitted project log yet">
+                            <%= team.team_name %>
+                          </span>
+                        </td>
+                        <td>
+                          <a href="#" class="btn btn-default" disabled="disabled">
+                            View
+                          </a>
+                        </td>
+                        <td>
+                          Not submitted yet
+                        </td>
+                      </tr>
+                    <% end %>
+                  <% end %>
+                  <% if locals[:mentor].teams.length <= 0 %>
+                    <tr><td colspan="3">No teams to display yet</td></tr>
+                  <% end %>
+                </tbody>
+            </table>
+          </div>
+        </div>
       </div>
-      <hr>
+    </div>
+    <hr>
     <% end %>
     <br><hr>
     You can send emails to your students via

--- a/app/views/mentors/_mentors_teams.html.erb
+++ b/app/views/mentors/_mentors_teams.html.erb
@@ -1,0 +1,22 @@
+<div class="table-responsive">
+  <table class="table table-hover">
+    <thead>
+    <tr>
+      <th>Team Name</th>
+      <th>Level of achievement</th>
+    </tr>
+    </thead>
+    <tbody>
+      <% locals[:mentor].teams.each do |team| %>
+        <tr>
+          <td>
+            <a href="<%= team_path(team) %>" class="btn btn-info"><%= team.team_name %></a>
+          </td>
+          <td>
+            <%= team.get_project_level %>
+          </td>
+        </tr>
+      <% end %>
+    </tbody>
+  </table>
+</div>


### PR DESCRIPTION
In reference to Issue #571 
* Allow mentors to view profiles of teams assigned to them
* Allowing mentors to view submitted milestones was already implemented, I did test it and it works well 