### PR TITLE
Feature to Lock/Unlock project level

### DIFF
--- a/app/controllers/admins_controller.rb
+++ b/app/controllers/admins_controller.rb
@@ -40,4 +40,13 @@ class AdminsController < RolesController
     end
     redirect_to admin_path(params[:id])
   end
+
+  def toggle_project_level_swap
+    if ENV['PROJECT_LEVEL_SWAP_STATUS'] == 'locked'
+      ENV['PROJECT_LEVEL_SWAP_STATUS'] = 'unlocked'
+    else
+      ENV['PROJECT_LEVEL_SWAP_STATUS'] = 'locked'
+    end
+    redirect_to admin_path(params[:id])
+  end
 end

--- a/app/helpers/admins_helper.rb
+++ b/app/helpers/admins_helper.rb
@@ -7,7 +7,11 @@ module AdminsHelper
     ENV['REGISTRATION_STATUS'] == 'open'
   end
 
-  def is_level_locked?
-    return true
+  def project_level_swap_status
+    ENV['PROJECT_LEVEL_SWAP_STATUS']
+  end
+
+  def is_project_level_locked?
+    ENV['PROJECT_LEVEL_SWAP_STATUS'] == 'locked'
   end
 end

--- a/app/helpers/admins_helper.rb
+++ b/app/helpers/admins_helper.rb
@@ -6,4 +6,8 @@ module AdminsHelper
   def is_registration_open?
     ENV['REGISTRATION_STATUS'] == 'open'
   end
+
+  def is_level_locked?
+    return true
+  end
 end

--- a/app/views/admins/_admin_view.html.erb
+++ b/app/views/admins/_admin_view.html.erb
@@ -40,6 +40,13 @@
             <% else %>
               <%= link_to 'Open', toggle_registration_admin_path(locals[:admin].id), class: 'btn btn-success', data: {confirm: 'Are you sure you want to open registration?'} %>
             <% end %>
+            <br>
+            <h5>Project Level Swap Status: <%= project_level_swap_status %></h5>
+            <% if is_project_level_locked? %>
+              <%= link_to 'Close', toggle_project_level_swap_admin_path(locals[:admin].id), class: 'btn btn-danger', data: {confirm: 'Are you sure you want to lock project level?'} %>
+            <% else %>
+              <%= link_to 'Open', toggle_project_level_swap_admin_path(locals[:admin].id), class: 'btn btn-success', data: {confirm: 'Are you sure you want to unlock project level?'} %>
+            <% end %>
           </div>
         </div>
       </div>

--- a/app/views/admins/_admin_view.html.erb
+++ b/app/views/admins/_admin_view.html.erb
@@ -43,9 +43,9 @@
             <br>
             <h5>Project Level Swap Status: <%= project_level_swap_status %></h5>
             <% if is_project_level_locked? %>
-              <%= link_to 'Close', toggle_project_level_swap_admin_path(locals[:admin].id), class: 'btn btn-danger', data: {confirm: 'Are you sure you want to lock project level?'} %>
+              <%= link_to 'Unlock', toggle_project_level_swap_admin_path(locals[:admin].id), class: 'btn btn-success', data: {confirm: 'Are you sure you want to unlock project level?'} %>
             <% else %>
-              <%= link_to 'Open', toggle_project_level_swap_admin_path(locals[:admin].id), class: 'btn btn-success', data: {confirm: 'Are you sure you want to unlock project level?'} %>
+              <%= link_to 'Lock', toggle_project_level_swap_admin_path(locals[:admin].id), class: 'btn btn-danger', data: {confirm: 'Are you sure you want to lock project level?'} %>
             <% end %>
           </div>
         </div>

--- a/app/views/teams/_team_form.html.erb
+++ b/app/views/teams/_team_form.html.erb
@@ -2,7 +2,7 @@
                     url: {action: (locals[:is_new] ? 'create' : 'update')}) do |f| %>
   <%= f.error_notification %>
   <%= f.input :team_name %>
-  <% if not is_level_locked? %>
+  <% if not is_project_level_locked? %>
     <%= f.input :project_level, collection: {Vostok: 'Vostok',
                                             'Project Gemini'.to_sym => 'Project Gemini',
                                             'Apollo 11'.to_sym => 'Apollo 11'},

--- a/app/views/teams/_team_form.html.erb
+++ b/app/views/teams/_team_form.html.erb
@@ -2,7 +2,14 @@
                     url: {action: (locals[:is_new] ? 'create' : 'update')}) do |f| %>
   <%= f.error_notification %>
   <%= f.input :team_name %>
-  <% if not is_project_level_locked? %>
+  <% if is_project_level_locked? %>
+    <div class="form-group string required team_team_name">
+      <label class="string required col-sm-3 control-label"> Project level </label>
+      <div class="col-sm-9">
+        <p class="string required form-control"><%= locals[:team].get_project_level %></p>
+      </div>
+    </div>
+  <% else %>
     <%= f.input :project_level, collection: {Vostok: 'Vostok',
                                             'Project Gemini'.to_sym => 'Project Gemini',
                                             'Apollo 11'.to_sym => 'Apollo 11'},

--- a/app/views/teams/_team_form.html.erb
+++ b/app/views/teams/_team_form.html.erb
@@ -2,11 +2,13 @@
                     url: {action: (locals[:is_new] ? 'create' : 'update')}) do |f| %>
   <%= f.error_notification %>
   <%= f.input :team_name %>
-  <%= f.input :project_level, collection: {Vostok: 'Vostok',
-                                           'Project Gemini'.to_sym => 'Project Gemini',
-                                           'Apollo 11'.to_sym => 'Apollo 11'},
-                              selected: locals[:team].get_project_level,
-                              include_blank: false, required: true %>
+  <% if not is_level_locked? %>
+    <%= f.input :project_level, collection: {Vostok: 'Vostok',
+                                            'Project Gemini'.to_sym => 'Project Gemini',
+                                            'Apollo 11'.to_sym => 'Apollo 11'},
+                                selected: locals[:team].get_project_level,
+                                include_blank: false, required: true %>
+  <% end %>
   <% if current_user_admin? %>
     <%= f.input :adviser_id, collection: locals[:advisers].map {|adviser| [adviser.user.user_name, adviser.id]}, include_blank: 'Not assigned', required: true %>
     <%= f.input :mentor_id, collection: locals[:mentors].map {|mentor| [mentor.user.user_name, mentor.id]}, include_blank: 'Not assigned' %>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -50,6 +50,7 @@ Rails.application.routes.draw do
   resources :admins, only: [:index, :new, :create, :show, :destroy] do
     member do
       get 'toggle_registration'
+      get 'toggle_project_level_swap'
       get 'general_mailing'
       post 'send_general_mailing'
       patch 'send_general_mailing'


### PR DESCRIPTION
Solves issue #557
Add feature to freeze and unfreeze level of achievement. Implementation is similar to #585 and also requires a new environment variable to be set using `declare -x PROJECT_LEVEL_SWAP_STATUS="locked"`