### PR TITLE
Carousel: fix the h5 styling by adding a separate class

### DIFF
--- a/app/assets/stylesheets/public_views/3-col-portfolio.css
+++ b/app/assets/stylesheets/public_views/3-col-portfolio.css
@@ -106,10 +106,3 @@ h5 {
   border-top-left-radius: 10px;
   border-top-right-radius: 10px;
 }
-
-.full-screen {
-  background-size: cover;
-  background-position: center;
-  background-repeat: no-repeat;
-  width: 100%; /*slider width*/
-}

--- a/app/assets/stylesheets/public_views/3-col-portfolio.css
+++ b/app/assets/stylesheets/public_views/3-col-portfolio.css
@@ -98,8 +98,8 @@ footer {
     padding: 12px 30px;
 }
 
-h5 {
 /* Carousel caption styling */
+.info {
   display: inline-block;
   padding: 10px;
   background: #B9121B;

--- a/app/assets/stylesheets/public_views/3-col-portfolio.css
+++ b/app/assets/stylesheets/public_views/3-col-portfolio.css
@@ -99,6 +99,7 @@ footer {
 }
 
 h5 {
+/* Carousel caption styling */
   display: inline-block;
   padding: 10px;
   background: #B9121B;

--- a/app/assets/stylesheets/public_views/3-col-portfolio.css
+++ b/app/assets/stylesheets/public_views/3-col-portfolio.css
@@ -102,7 +102,7 @@ footer {
 .info {
   display: inline-block;
   padding: 10px;
-  background: #B9121B;
   border-top-left-radius: 10px;
   border-top-right-radius: 10px;
+  background: #F26D21;
 }

--- a/app/views/public_views/group_carousel/index.html.erb
+++ b/app/views/public_views/group_carousel/index.html.erb
@@ -7,8 +7,6 @@
     <ol class="carousel-indicators">
       <% images.each_with_index do |image, index| %>
       <li data-target="#carousel" data-slide-to="<%= index %>" class="<%= index == 0 ? 'active' : '' %>"></li>
-      <!-- <li data-target="#carousel" data-slide-to="<%= index %>" ></li>
-      <li data-target="#carousel" data-slide-to="<%= index %>"></li> -->
       <% end %>
     </ol>
     <!-- Wrapper for slides -->

--- a/app/views/public_views/group_carousel/index.html.erb
+++ b/app/views/public_views/group_carousel/index.html.erb
@@ -13,9 +13,9 @@
     <div class="carousel-inner" role="listbox">
       <% images.each_with_index do |image, index| %>
         <div class="item <%= index == 0 ? 'active' : '' %>">
-          <img class="full-screen" src="<%= image %> " alt="<%= index %>  Image">
+          <img src="<%= image %>" alt="<%= index %> Image">
           <div class="carousel-caption d-md-block">
-            <h5><%= @team_names[index]%></h5>
+            <h5 class="info"><%= @team_names[index]%></h5>
           </div>
         </div>
       <% end %>

--- a/app/views/public_views/mentor_slides/index.html.erb
+++ b/app/views/public_views/mentor_slides/index.html.erb
@@ -11,9 +11,9 @@
     <div class="carousel-inner" role="listbox">
       <% images.each_with_index do |image, index| %>
         <div class="item <%= index == 0 ? 'active' : '' %>">
-          <img class="full-screen" src="<%= image %> " alt="<%= index %>  Image">
+          <img src="<%= image %>" alt="<%= index %> Image">
           <div class="carousel-caption d-md-block">
-            <h5><%= @names[index] %></h5>
+            <h5 class="info"><%= @names[index] %><h5>
           </div>
         </div>
       <% end %>

--- a/app/views/public_views/mentor_slides/index.html.erb
+++ b/app/views/public_views/mentor_slides/index.html.erb
@@ -5,8 +5,6 @@
     <ol class="carousel-indicators">
       <% images.each_with_index do |image, index| %>
       <li data-target="#carousel" data-slide-to="<%= index %>" class="<%= index == 0 ? 'active' : '' %>"></li>
-      <!-- <li data-target="#carousel" data-slide-to="<%= index %>" ></li>
-      <li data-target="#carousel" data-slide-to="<%= index %>"></li> -->
       <% end %>
     </ol>
     <!-- Wrapper for slides -->


### PR DESCRIPTION
Fixes #619 

Also refactored some code in the carousel. No change to the end product on the page.
Used a class name called `info` to style it, not sure if there is any other names...

![screen shot 2018-06-08 at 2 37 26 pm](https://user-images.githubusercontent.com/28522090/41142862-dda1c6fe-6b29-11e8-87bf-eedca37be6cc.png)
