### PR TITLE
#626 Public Projects to show individual team's poster instead of merely icons

### DIFF
--- a/app/assets/stylesheets/public_views/3-col-portfolio.css
+++ b/app/assets/stylesheets/public_views/3-col-portfolio.css
@@ -112,3 +112,8 @@ h5 {
   background-repeat: no-repeat;
   width: 100%; /*slider width*/
 }
+
+.inactive_link {
+   pointer-events: none;
+   cursor: default;
+}

--- a/app/views/public_views/public_projects/_public_teams_table.html.erb
+++ b/app/views/public_views/public_projects/_public_teams_table.html.erb
@@ -44,7 +44,7 @@
     </a>
     <!-- createModalBox(<%= team.team_name %>) -->
     <h3>
-        <button class="button button_team" onclick="createModalBox(<%= team.id %>)" id="button_<%= team.id %>"><%= idx + 1 %>. <strong><%= team.team_name %></strong></button> <!-- Clicking the link creates another layer of window that shows the team's project -->
+      <button class="button button_team" onclick="createModalBox(<%= team.id %>)" id="button_<%= team.id %>"><%= idx + 1 %>. <strong><%= team.team_name %></strong></button> <!-- Clicking the link creates another layer of window that shows the team's project -->
     </h3>
     <p class="text-muted">Students: <%= team.students.map{|student| student.user.user_name}.join(' & ') %></p>
     <p class="text-muted">Advised by: <%= team.adviser ? team.adviser.user.user_name : 'Not assigned' %></p>

--- a/app/views/public_views/public_projects/_public_teams_table.html.erb
+++ b/app/views/public_views/public_projects/_public_teams_table.html.erb
@@ -31,14 +31,14 @@
   <!-- The Project Profile -->
   <div class="col-md-4 portfolio-item">
     <a role="button" onclick="createModalBox(<%= team.team_name %>)" id="button_<%= team.team_name %>">
-      <% if locals[:selected_type] == 'Vostok' %>
-      <%= link_to image_tag("Vostok_Icon.jpg", class: 'img-rounded') %>
       <% if !team.poster_link.blank? %>
         <%= link_to image_tag(team.poster_link, size: "200", alt: "Team's Poster Link is not in image form"), team.poster_link %>
+      <% elsif locals[:selected_type] == 'Vostok' %>
+        <%= image_tag("Vostok_Icon.png", size: "200", class: 'img-rounded inactive_link') %>
       <% elsif locals[:selected_type] == 'Project Gemini' %>
-      <%= link_to image_tag("Project_Gemini_Icon.png", class: 'img-rounded') %>
+        <%= image_tag("Project_Gemini_Icon.png", size: "200", class: 'img-rounded inactive_link') %>
       <% elsif locals[:selected_type] == 'Apollo 11' %>
-      <%= link_to image_tag("Apollo_11_Icon.png", class: 'img-rounded') %>
+        <%= image_tag("Apollo_11_Icon.png", size: "200", class: 'img-rounded inactive_link') %>
       <% end %>
     </a>
     <!-- createModalBox(<%= team.team_name %>) -->

--- a/app/views/public_views/public_projects/_public_teams_table.html.erb
+++ b/app/views/public_views/public_projects/_public_teams_table.html.erb
@@ -27,7 +27,6 @@
           </h1>
       </div>
   </div>
-  <!-- /.row -->
   <% locals[:selected_teams].each_with_index do |team, idx| %>
   <!-- The Project Profile -->
   <div class="col-md-4 portfolio-item">

--- a/app/views/public_views/public_projects/_public_teams_table.html.erb
+++ b/app/views/public_views/public_projects/_public_teams_table.html.erb
@@ -33,6 +33,8 @@
     <a role="button" onclick="createModalBox(<%= team.team_name %>)" id="button_<%= team.team_name %>">
       <% if locals[:selected_type] == 'Vostok' %>
       <%= link_to image_tag("Vostok_Icon.jpg", class: 'img-rounded') %>
+      <% if !team.poster_link.blank? %>
+        <%= link_to image_tag(team.poster_link, size: "200", alt: "Team's Poster Link is not in image form"), team.poster_link %>
       <% elsif locals[:selected_type] == 'Project Gemini' %>
       <%= link_to image_tag("Project_Gemini_Icon.png", class: 'img-rounded') %>
       <% elsif locals[:selected_type] == 'Apollo 11' %>

--- a/app/views/public_views/public_projects/_public_teams_table.html.erb
+++ b/app/views/public_views/public_projects/_public_teams_table.html.erb
@@ -15,11 +15,10 @@
     <![endif]-->
 </head>
 <body>
-  <div class="row">
-  <div class="center"><h2><%= number_to_percentage(100.0 * locals[:selected_teams].length.to_f / locals[:teams].length.to_f, precision: 0) %> of the cohort</h2></div>
-  </div>
-  
   <!-- Page Content -->
+  <div class="row">
+    <div class="center"><h2><%= number_to_percentage(100.0 * locals[:selected_teams].length.to_f / locals[:teams].length.to_f, precision: 0) %> of the cohort</h2></div>
+  </div>
   <!-- Page Header -->
   <div class="row">
       <div class="col-lg-12">

--- a/app/views/public_views/public_projects/_public_teams_table.html.erb
+++ b/app/views/public_views/public_projects/_public_teams_table.html.erb
@@ -32,7 +32,8 @@
   <div class="col-md-4 portfolio-item">
     <a role="button" onclick="createModalBox(<%= team.team_name %>)" id="button_<%= team.team_name %>">
       <% if !team.poster_link.blank? %>
-        <%= link_to image_tag(team.poster_link, size: "200", alt: "Team's Poster Link is not in image form"), team.poster_link %>
+        <%= link_to image_tag(team.poster_link, size: "200", alt: "Team's Poster Link is not in image form",
+          title: "Click to view an enlarged version of this image."), team.poster_link %>
       <% elsif locals[:selected_type] == 'Vostok' %>
         <%= image_tag("Vostok_Icon.png", size: "200", class: 'img-rounded inactive_link') %>
       <% elsif locals[:selected_type] == 'Project Gemini' %>

--- a/app/views/public_views/public_projects/index.html.erb
+++ b/app/views/public_views/public_projects/index.html.erb
@@ -20,25 +20,25 @@
 		<div class="tab-content">
 			<div id="vostok<%=cohort%>" class="tab-pane fade in active">
 				<% if teams.select{|team| team.vostok?}.length > 0 %>
-				<%= render 'public_teams_table', locals: {teams: teams,
-					selected_teams: teams.select{|team| team.vostok?},
-					selected_type: 'Vostok'} %>
+					<%= render 'public_teams_table', locals: {teams: teams,
+						selected_teams: teams.select{|team| team.vostok?},
+						selected_type: 'Vostok'} %>
 				<% else %>
 					No Data Available
 				<% end %>
 			</div>
 			<div id="project_gemini<%=cohort%>" class="tab-pane fade">
 				<% if teams.select{|team| team.project_gemini?}.length > 0 %>
-				<%= render 'public_teams_table', locals: {teams: teams,
-					selected_teams: teams.select{|team| team.project_gemini?},
-					selected_type: 'Project Gemini'} %>
+					<%= render 'public_teams_table', locals: {teams: teams,
+						selected_teams: teams.select{|team| team.project_gemini?},
+						selected_type: 'Project Gemini'} %>
 				<% else %>
 					No Data Available
 				<% end %>
 			</div>
 			<div id="apollo_11<%=cohort%>" class="tab-pane fade">
 				<% if teams.select{|team| team.apollo_11?}.length > 0 %>
-				<%= render 'public_teams_table', locals: {teams: teams,
+					<%= render 'public_teams_table', locals: {teams: teams,
 						selected_teams: teams.select{|team| team.apollo_11?},
 						selected_type: 'Apollo 11'} %>
 				<% else %>

--- a/app/views/public_views/public_projects/index.html.erb
+++ b/app/views/public_views/public_projects/index.html.erb
@@ -23,29 +23,29 @@
 				<%= render 'public_teams_table', locals: {teams: teams,
 					selected_teams: teams.select{|team| team.vostok?},
 					selected_type: 'Vostok'} %>
-					<% else %>
+				<% else %>
 					No Data Available
-					<% end %>
-				</div>
-				<div id="project_gemini<%=cohort%>" class="tab-pane fade">
-					<% if teams.select{|team| team.project_gemini?}.length > 0 %>
-					<%= render 'public_teams_table', locals: {teams: teams,
-						selected_teams: teams.select{|team| team.project_gemini?},
-						selected_type: 'Project Gemini'} %>
-						<% else %>
-						No Data Available
-						<% end %>
-					</div>
-					<div id="apollo_11<%=cohort%>" class="tab-pane fade">
-						<% if teams.select{|team| team.apollo_11?}.length > 0 %>
-						<%= render 'public_teams_table', locals: {teams: teams,
-							selected_teams: teams.select{|team| team.apollo_11?},
-							selected_type: 'Apollo 11'} %>
-							<% else %>
-							No Data Available
-							<% end %>
-						</div>
-					</div>
-				</div>
 				<% end %>
 			</div>
+			<div id="project_gemini<%=cohort%>" class="tab-pane fade">
+				<% if teams.select{|team| team.project_gemini?}.length > 0 %>
+				<%= render 'public_teams_table', locals: {teams: teams,
+					selected_teams: teams.select{|team| team.project_gemini?},
+					selected_type: 'Project Gemini'} %>
+				<% else %>
+					No Data Available
+				<% end %>
+			</div>
+			<div id="apollo_11<%=cohort%>" class="tab-pane fade">
+				<% if teams.select{|team| team.apollo_11?}.length > 0 %>
+				<%= render 'public_teams_table', locals: {teams: teams,
+						selected_teams: teams.select{|team| team.apollo_11?},
+						selected_type: 'Apollo 11'} %>
+				<% else %>
+					No Data Available
+				<% end %>
+			</div>
+		</div>
+	</div>
+<% end %>
+</div>

--- a/test/fixtures/students.yml
+++ b/test/fixtures/students.yml
@@ -2,22 +2,66 @@
 <% (10..20).each do |n| %>
 stu_<%= n %>:
   id: <%= n %>
-  user_id: <%= n %> 
+  user_id: <%= n %>
   created_at: <%= 0.days.from_now.to_s :db %>
   updated_at: <%= 0.days.from_now.to_s :db %>
   team_id:
   is_pending: TRUE
-  cohort: 2018	
+  cohort: 2018
 <% end %>
 
 # fixtures for students cohort 2017
-<% (1710..1720).each do |n| %>
+<% (1710..1712).each do |n| %>
 stu_<%= n %>:
   id: <%= n %>
-  user_id: <%= n %> 
+  user_id: <%= n %>
   created_at: <%= 0.days.from_now.to_s :db %>
   updated_at: <%= 0.days.from_now.to_s :db %>
-  team_id:
-  is_pending: TRUE
-  cohort: 2017	
+  team_id: 1723
+  is_pending: false
+  cohort: 2017
+<% end %>
+
+<% (1713..1714).each do |n| %>
+stu_<%= n %>:
+  id: <%= n %>
+  user_id: <%= n %>
+  created_at: <%= 0.days.from_now.to_s :db %>
+  updated_at: <%= 0.days.from_now.to_s :db %>
+  team_id: 1724
+  is_pending: false
+  cohort: 2017
+<% end %>
+
+<% (1715..1716).each do |n| %>
+stu_<%= n %>:
+  id: <%= n %>
+  user_id: <%= n %>
+  created_at: <%= 0.days.from_now.to_s :db %>
+  updated_at: <%= 0.days.from_now.to_s :db %>
+  team_id: 1725
+  is_pending: false
+  cohort: 2017
+<% end %>
+
+<% (1717..1718).each do |n| %>
+stu_<%= n %>:
+  id: <%= n %>
+  user_id: <%= n %>
+  created_at: <%= 0.days.from_now.to_s :db %>
+  updated_at: <%= 0.days.from_now.to_s :db %>
+  team_id: 1727
+  is_pending: false
+  cohort: 2017
+<% end %>
+
+<% (1719..1720).each do |n| %>
+stu_<%= n %>:
+  id: <%= n %>
+  user_id: <%= n %>
+  created_at: <%= 0.days.from_now.to_s :db %>
+  updated_at: <%= 0.days.from_now.to_s :db %>
+  team_id: 1729
+  is_pending: false
+  cohort: 2017
 <% end %>

--- a/test/fixtures/students.yml
+++ b/test/fixtures/students.yml
@@ -17,7 +17,7 @@ stu_<%= n %>:
   user_id: <%= n %>
   created_at: <%= 0.days.from_now.to_s :db %>
   updated_at: <%= 0.days.from_now.to_s :db %>
-  team_id: 1723
+  team_id: 1731
   is_pending: false
   cohort: 2017
 <% end %>
@@ -28,7 +28,7 @@ stu_<%= n %>:
   user_id: <%= n %>
   created_at: <%= 0.days.from_now.to_s :db %>
   updated_at: <%= 0.days.from_now.to_s :db %>
-  team_id: 1724
+  team_id: 1732
   is_pending: false
   cohort: 2017
 <% end %>
@@ -39,7 +39,7 @@ stu_<%= n %>:
   user_id: <%= n %>
   created_at: <%= 0.days.from_now.to_s :db %>
   updated_at: <%= 0.days.from_now.to_s :db %>
-  team_id: 1725
+  team_id: 1733
   is_pending: false
   cohort: 2017
 <% end %>
@@ -50,18 +50,25 @@ stu_<%= n %>:
   user_id: <%= n %>
   created_at: <%= 0.days.from_now.to_s :db %>
   updated_at: <%= 0.days.from_now.to_s :db %>
-  team_id: 1727
+  team_id: 1735
   is_pending: false
   cohort: 2017
 <% end %>
 
-<% (1719..1720).each do |n| %>
-stu_<%= n %>:
-  id: <%= n %>
-  user_id: <%= n %>
+stu_1719:
+  id: 1719
+  user_id: 1719
   created_at: <%= 0.days.from_now.to_s :db %>
   updated_at: <%= 0.days.from_now.to_s :db %>
-  team_id: 1729
+  team_id: 1737
   is_pending: false
   cohort: 2017
-<% end %>
+
+stu_1720:
+  id: 1720
+  user_id: 1720
+  created_at: <%= 0.days.from_now.to_s :db %>
+  updated_at: <%= 0.days.from_now.to_s :db %>
+  team_id: 1739
+  is_pending: false
+  cohort: 2017

--- a/test/fixtures/teams.yml
+++ b/test/fixtures/teams.yml
@@ -1,6 +1,8 @@
 # fixtures for teams cohort 2017
-<% (1723..1724).each do |n| %>
+# 1731-1734 vostok, 1735-1737 gemini, 1738-1740 apollo_11
+<% (1731..1732).each do |n| %>
 team_<%= n %>:
+  id: <%= n %>
   adviser_id: 1706
   mentor_id:
   created_at: <%= 0.days.from_now.to_s :db %>
@@ -14,8 +16,9 @@ team_<%= n %>:
   video_link: "https://www.youtube.com/watch?v=MAjY8mCTXWk"
 <% end %>
 
-<% (1725..1726).each do |n| %>
+<% (1733..1734).each do |n| %>
 team_<%= n %>:
+  id: <%= n %>
   adviser_id: 1707
   mentor_id:
   created_at: <%= 0.days.from_now.to_s :db %>
@@ -29,8 +32,9 @@ team_<%= n %>:
   video_link: "https://www.youtube.com/watch?v=kfXdP7nZIiE"
 <% end %>
 
-<% (1727..1728).each do |n| %>
+<% (1735..1736).each do |n| %>
 team_<%= n %>:
+  id: <%= n %>
   adviser_id: 1708
   mentor_id:
   created_at: <%= 0.days.from_now.to_s :db %>
@@ -44,8 +48,23 @@ team_<%= n %>:
   video_link: "https://www.youtube.com/watch?v=TMB6-YflpA4"
 <% end %>
 
-<% (1729..1730).each do |n| %>
+team_1737:
+  id: 1737
+  adviser_id: 1708
+  mentor_id:
+  created_at: <%= 0.days.from_now.to_s :db %>
+  updated_at: <%= 0.days.from_now.to_s :db %>
+  team_name: "I am team 1737"
+  has_dropped: false
+  project_level: 1
+  is_pending: false
+  cohort: 2017
+  poster_link: null
+  video_link:
+
+<% (1738..1739).each do |n| %>
 team_<%= n %>:
+  id: <%= n %>
   adviser_id: 1709
   mentor_id:
   created_at: <%= 0.days.from_now.to_s :db %>
@@ -58,3 +77,17 @@ team_<%= n %>:
   poster_link: "https://i.pinimg.com/736x/28/3d/1d/283d1d5648c027afa6cdb6c9535ce152--funny-monday-memes-monday-quotes.jpg"
   video_link: "https://www.youtube.com/watch?v=eS2T9IiOYbc"
 <% end %>
+
+team_1740:
+  id: 1740
+  adviser_id: 1708
+  mentor_id:
+  created_at: <%= 0.days.from_now.to_s :db %>
+  updated_at: <%= 0.days.from_now.to_s :db %>
+  team_name: "I am team 1740"
+  has_dropped: false
+  project_level: 2
+  is_pending: false
+  cohort: 2017
+  poster_link:
+  video_link:

--- a/test/fixtures/teams.yml
+++ b/test/fixtures/teams.yml
@@ -1,1 +1,60 @@
+# fixtures for teams cohort 2017
+<% (1723..1724).each do |n| %>
+team_<%= n %>:
+  adviser_id: 1706
+  mentor_id:
+  created_at: <%= 0.days.from_now.to_s :db %>
+  updated_at: <%= 0.days.from_now.to_s :db %>
+  team_name: "I am team <%= n %>"
+  has_dropped: false
+  project_level: 0
+  is_pending: false
+  cohort: 2017
+  poster_link: "http://beardstyle.net/wp-content/uploads/2016/06/girls-with-mustaches-6.jpg"
+  video_link: "https://www.youtube.com/watch?v=MAjY8mCTXWk"
+<% end %>
 
+<% (1725..1726).each do |n| %>
+team_<%= n %>:
+  adviser_id: 1707
+  mentor_id:
+  created_at: <%= 0.days.from_now.to_s :db %>
+  updated_at: <%= 0.days.from_now.to_s :db %>
+  team_name: "I am team <%= n %>"
+  has_dropped: false
+  project_level: 0
+  is_pending: false
+  cohort: 2017
+  poster_link: "http://limingu.com/wp-content/uploads/2018/01/blonde-asian.jpg"
+  video_link: "https://www.youtube.com/watch?v=kfXdP7nZIiE"
+<% end %>
+
+<% (1727..1728).each do |n| %>
+team_<%= n %>:
+  adviser_id: 1708
+  mentor_id:
+  created_at: <%= 0.days.from_now.to_s :db %>
+  updated_at: <%= 0.days.from_now.to_s :db %>
+  team_name: "I am team <%= n %>"
+  has_dropped: false
+  project_level: 1
+  is_pending: false
+  cohort: 2017
+  poster_link: "https://www.planwallpaper.com/static/images/funny-527.jpg"
+  video_link: "https://www.youtube.com/watch?v=TMB6-YflpA4"
+<% end %>
+
+<% (1729..1730).each do |n| %>
+team_<%= n %>:
+  adviser_id: 1709
+  mentor_id:
+  created_at: <%= 0.days.from_now.to_s :db %>
+  updated_at: <%= 0.days.from_now.to_s :db %>
+  team_name: "I am team <%= n %>"
+  has_dropped: false
+  project_level: 2
+  is_pending: false
+  cohort: 2017
+  poster_link: "https://i.pinimg.com/736x/28/3d/1d/283d1d5648c027afa6cdb6c9535ce152--funny-monday-memes-monday-quotes.jpg"
+  video_link: "https://www.youtube.com/watch?v=eS2T9IiOYbc"
+<% end %>

--- a/test/fixtures/users.yml
+++ b/test/fixtures/users.yml
@@ -26,8 +26,9 @@ user_<%= n %>:
   matric_number:
 <% end %>
 
-#user_id 1702-1705: admins, 1706-1709: advisers, 1710-1720: students, 1721-1722: mentors 
-#for cohort 2017  
+#1700-1730 are user ids, 1731-1745 teams, 1746-1760 submissions, 1761-1775 milestones, 1776-1799 evaluatings and peer_evaluations
+#user_id 1702-1705: admins, 1706-1709: advisers, 1710-1720: students, 1721-1722: mentors
+#for cohort 2017
 <% (1702..1722).each do |n| %>
 user_<%= n %>:
   id: <%= n %>


### PR DESCRIPTION
Fixes #626 

In each of the teams under public projects tab, show the poster image teams submitted for milestone0 instead of merely team icons.

If there is no poster link submitted, the image will show a default icon as shown below. On top of that, the poster images populated for each team is clickable to link them to see a bigger version of the image. 

![screen shot 2018-06-08 at 11 18 11 pm](https://user-images.githubusercontent.com/28522090/41167340-2f8eb8a0-6b75-11e8-916d-3950573f3f16.png)

However, the only issue is that if it is not a poster_link that ends with image tag, it does not show anything. Not sure how to fix this yet.