### PR TITLE
#609 Project past teams modal in a better format

### DIFF
--- a/app/assets/stylesheets/public_views/3-col-portfolio.css
+++ b/app/assets/stylesheets/public_views/3-col-portfolio.css
@@ -98,6 +98,7 @@ footer {
     border-radius: 8px;
     border: 2px solid #4CAF50;
     padding: 12px 30px;
+    display: inline-block;
 }
 .button_video:hover {
     background-color: white;

--- a/app/assets/stylesheets/public_views/3-col-portfolio.css
+++ b/app/assets/stylesheets/public_views/3-col-portfolio.css
@@ -80,12 +80,12 @@ footer {
     padding: 14px 40px;
 }
 .button_team_disabled {
-  background-color: #999999;
-  color: white;
-  font-size: 16px;
-  border-radius: 8px;
-  border: 2px solid #999999;
-  padding: 14px 40px;
+    background-color: #999999;
+    color: white;
+    font-size: 16px;
+    border-radius: 8px;
+    border: 2px solid #999999;
+    padding: 14px 40px;
 }
 
 /* Watch video button */

--- a/app/assets/stylesheets/public_views/3-col-portfolio.css
+++ b/app/assets/stylesheets/public_views/3-col-portfolio.css
@@ -43,8 +43,10 @@ footer {
     margin: 15% auto; /* 15% from the top and centered */
     padding: 20px;
     border: 1px solid #888;
-    width: 50%; /* Could be more or less, depending on screen size */
-    height: 40%;
+    width: 600px;
+    max-width: 100%;
+    height: 300px;
+    max-height: 100%;
 }
 
 /* The Close Button */

--- a/app/assets/stylesheets/public_views/3-col-portfolio.css
+++ b/app/assets/stylesheets/public_views/3-col-portfolio.css
@@ -79,6 +79,14 @@ footer {
     border-radius: 8px;
     padding: 14px 40px;
 }
+.button_team_disabled {
+  background-color: #999999;
+  color: white;
+  font-size: 16px;
+  border-radius: 8px;
+  border: 2px solid #999999;
+  padding: 14px 40px;
+}
 
 /* Watch video button */
 .button_video {

--- a/app/views/public_views/public_projects/_public_teams_table.html.erb
+++ b/app/views/public_views/public_projects/_public_teams_table.html.erb
@@ -84,8 +84,8 @@
     function createModalBox(team_id) {
       var modal = document.getElementById("modal_".concat(team_id));
       var button = document.getElementById("button_".concat(team_id));
-      var span = document.getElementsByClassName("close")[0];
       console.log("Success!");
+      var span = document.getElementById("modal_".concat(team_id)).getElementsByClassName("close")[0];
       modal.style.display = "block";
       span.onclick = function() {
         modal.style.display = "none";

--- a/app/views/public_views/public_projects/_public_teams_table.html.erb
+++ b/app/views/public_views/public_projects/_public_teams_table.html.erb
@@ -67,15 +67,27 @@
       <br><hr>
       <h4 class="text-muted">Links</h4>
       <br>
-      <div class="col-md-6">
-	      <a role="button" class="button button_video" href="<%= Submission.where(team_id: team.id)[-1].video_link %>">Watch Project Video</a>
-      </div>
-      <div class="col-md-6">
-        <a role="button" class="button button_video" href="<%= Submission.where(team_id: team.id)[-1].poster_link %>">View Project Poster</a>
-      </div>
       <% if (submission_local) %>
+        <% if (!submission_local.video_link.blank?) %>
+          <div class="col-md-6">
+            <a role="button" class="button button_video" href="<%= Submission.where(team_id: team.id)[-1].video_link %>">
+              Watch Project Video
+            </a>
+          </div>
+        <% else %>
+          <div>Video link is not submitted / not available.</div>
+        <% end %>
+        <% if (!submission_local.poster_link.blank?) %>
+          <div class="col-md-6">
+            <a role="button" class="button button_video" href="<%= Submission.where(team_id: team.id)[-1].poster_link %>">
+              View Project Poster
+            </a>
+          </div>
+        <% else %>
+          <div>Poster link is not submitted / not available.</div>
+        <% end %>
   	  <% else %>
-  	  	  <span>Video is not shown/not available</span>
+	  	  <div>There is no submission available to be shown.</div>
   	  <% end %>
     </div>
   </div>

--- a/app/views/public_views/public_projects/_public_teams_table.html.erb
+++ b/app/views/public_views/public_projects/_public_teams_table.html.erb
@@ -84,8 +84,8 @@
     function createModalBox(team_id) {
       var modal = document.getElementById("modal_".concat(team_id));
       var button = document.getElementById("button_".concat(team_id));
-      console.log("Success!");
       var span = document.getElementById("modal_".concat(team_id)).getElementsByClassName("close")[0];
+      
       modal.style.display = "block";
       span.onclick = function() {
         modal.style.display = "none";

--- a/app/views/public_views/public_projects/_public_teams_table.html.erb
+++ b/app/views/public_views/public_projects/_public_teams_table.html.erb
@@ -45,7 +45,8 @@
     <!-- createModalBox(<%= team.team_name %>) disabled if no submission present -->
     <!-- this assumes that submission has valid poster and video links -->
     <h3>
-      <% if (Submission.where(team_id: team.id)[-1]) %>
+      <% submission_local = Submission.where(team_id: team.id)[-1] %>
+      <% if (submission_local) %>
         <button class="button button_team" onclick="createModalBox(<%= team.id %>)" id="button_<%= team.id %>">
           <%= idx + 1 %>. <strong><%= team.team_name %></strong>
         </button>
@@ -66,13 +67,13 @@
       <br><hr>
       <h4 class="text-muted">Links</h4>
       <br>
-      <% if (Submission.where(team_id: team.id)[-1]) %>
       <div class="col-md-6">
 	      <a role="button" class="button button_video" href="<%= Submission.where(team_id: team.id)[-1].video_link %>">Watch Project Video</a>
       </div>
       <div class="col-md-6">
         <a role="button" class="button button_video" href="<%= Submission.where(team_id: team.id)[-1].poster_link %>">View Project Poster</a>
       </div>
+      <% if (submission_local) %>
   	  <% else %>
   	  	  <span>Video is not shown/not available</span>
   	  <% end %>

--- a/app/views/public_views/public_projects/_public_teams_table.html.erb
+++ b/app/views/public_views/public_projects/_public_teams_table.html.erb
@@ -68,6 +68,7 @@
         <h4 class="text-muted"><%= team.team_name %></h4>
       </center>
       <hr>
+      <h4 class="text-muted">Submission Links:</h4>
       <br>
       <% if (submission_local) %>
         <% if (!submission_local.video_link.blank?) %>

--- a/app/views/public_views/public_projects/_public_teams_table.html.erb
+++ b/app/views/public_views/public_projects/_public_teams_table.html.erb
@@ -59,6 +59,7 @@
     <p class="text-muted">Students: <%= team.students.map{|student| student.user.user_name}.join(' & ') %></p>
     <p class="text-muted">Advised by: <%= team.adviser ? team.adviser.user.user_name : 'Not assigned' %></p>
   </div>
+  <!-- ToDo: data for Modal Box is initialized even though the button is disabled. Inefficient loading page.-->
   <!-- The Modal Box -->
   <div id="modal_<%= team.id %>" class="modal">
     <div class="modal-content">

--- a/app/views/public_views/public_projects/_public_teams_table.html.erb
+++ b/app/views/public_views/public_projects/_public_teams_table.html.erb
@@ -42,7 +42,8 @@
         <%= image_tag("Apollo_11_Icon.png", size: "200", class: 'img-rounded inactive_link') %>
       <% end %>
     </a>
-    <!-- createModalBox(<%= team.team_name %>) -->
+    <!-- createModalBox(<%= team.team_name %>) disabled if no submission present -->
+    <!-- this assumes that submission has valid poster and video links -->
     <h3>
       <% if (Submission.where(team_id: team.id)[-1]) %>
         <button class="button button_team" onclick="createModalBox(<%= team.id %>)" id="button_<%= team.id %>">

--- a/app/views/public_views/public_projects/_public_teams_table.html.erb
+++ b/app/views/public_views/public_projects/_public_teams_table.html.erb
@@ -64,9 +64,10 @@
   <div id="modal_<%= team.id %>" class="modal">
     <div class="modal-content">
       <span class="close">&times;</span>
-      <h4 class="text-muted"><%= team.team_name %></h4>
-      <br><hr>
-      <h4 class="text-muted">Links</h4>
+      <center>
+        <h4 class="text-muted"><%= team.team_name %></h4>
+      </center>
+      <hr>
       <br>
       <% if (submission_local) %>
         <% if (!submission_local.video_link.blank?) %>

--- a/app/views/public_views/public_projects/_public_teams_table.html.erb
+++ b/app/views/public_views/public_projects/_public_teams_table.html.erb
@@ -44,7 +44,15 @@
     </a>
     <!-- createModalBox(<%= team.team_name %>) -->
     <h3>
-      <button class="button button_team" onclick="createModalBox(<%= team.id %>)" id="button_<%= team.id %>"><%= idx + 1 %>. <strong><%= team.team_name %></strong></button> <!-- Clicking the link creates another layer of window that shows the team's project -->
+      <% if (Submission.where(team_id: team.id)[-1]) %>
+        <button class="button button_team" onclick="createModalBox(<%= team.id %>)" id="button_<%= team.id %>">
+          <%= idx + 1 %>. <strong><%= team.team_name %></strong>
+        </button>
+      <% else %>
+        <button class="button button_team_disabled" id="button_<%= team.id %>" disabled>
+          <%= idx + 1 %>. <strong><%= team.team_name %></strong>
+        </button>
+      <% end %>
     </h3>
     <p class="text-muted">Students: <%= team.students.map{|student| student.user.user_name}.join(' & ') %></p>
     <p class="text-muted">Advised by: <%= team.adviser ? team.adviser.user.user_name : 'Not assigned' %></p>

--- a/test/fixtures/submissions.yml
+++ b/test/fixtures/submissions.yml
@@ -1,1 +1,132 @@
+# fixtures submissions for cohort 2017 (1746 - 1760)
+# 1731-1734 vostok, 1735-1737 gemini, 1738-1740 apollo_11
 
+submission_1746:
+  id: 1746
+  milestone_id: 1
+  team_id: 1731
+  published: false
+  created_at: <%= 0.days.from_now.to_s :db %>
+  updated_at: <%= 0.days.from_now.to_s :db %>
+  poster_link: "https://i.ytimg.com/vi/RTfvXkEXa-k/maxresdefault.jpg"
+  video_link: "https://www.youtube.com/watch?v=Tif2a8vXeAA"
+  read_me: "Hi I am testing out submission 1746"
+  project_log:
+  show_public: true
+
+submission_1747:
+  id: 1747
+  milestone_id: 2
+  team_id: 1732
+  published: false
+  created_at: <%= 0.days.from_now.to_s :db %>
+  updated_at: <%= 0.days.from_now.to_s :db %>
+  poster_link:
+  video_link:
+  read_me: "Hi I am testing out submission 1747"
+  project_log:
+  show_public: true
+
+submission_1748:
+  id: 1748
+  milestone_id: 3
+  team_id: 1733
+  published: false
+  created_at: <%= 0.days.from_now.to_s :db %>
+  updated_at: <%= 0.days.from_now.to_s :db %>
+  poster_link:
+  video_link: https://www.youtube.com/watch?v=a7nrDN15NPE
+  read_me: "Hi I am testing out submission 1748"
+  project_log:
+  show_public: true
+
+submission_1749:
+  id: 1749
+  milestone_id: 1
+  team_id: 1735
+  published: false
+  created_at: <%= 0.days.from_now.to_s :db %>
+  updated_at: <%= 0.days.from_now.to_s :db %>
+  poster_link: "https://i.ytimg.com/vi/XlUPuj2V6PM/maxresdefault.jpg"
+  video_link: "https://www.youtube.com/watch?v=CyYh1raLGBs"
+  read_me: "Hi I am testing out submission 1749"
+  project_log:
+  show_public: true
+
+submission_1750:
+  id: 1750
+  milestone_id: 2
+  team_id: 1735
+  published: false
+  created_at: <%= 0.days.from_now.to_s :db %>
+  updated_at: <%= 0.days.from_now.to_s :db %>
+  poster_link:
+  video_link:
+  read_me: "Hi I am testing out submission 1750"
+  project_log:
+  show_public: true
+
+submission_1751:
+  id: 1751
+  milestone_id: 3
+  team_id: 1735
+  published: false
+  created_at: <%= 0.days.from_now.to_s :db %>
+  updated_at: <%= 0.days.from_now.to_s :db %>
+  poster_link: "http://cdn.ebaumsworld.com/mediaFiles/picture/604025/84556534.jpg"
+  video_link: "https://www.youtube.com/watch?v=rk9pHHeEaKU"
+  read_me: "Hi I am testing out submission 1751"
+  project_log:
+  show_public: true
+
+submission_1752:
+  id: 1752
+  milestone_id: 1
+  team_id: 1738
+  published: false
+  created_at: <%= 0.days.from_now.to_s :db %>
+  updated_at: <%= 0.days.from_now.to_s :db %>
+  poster_link: "https://i.ytimg.com/vi/xzWEJkh800o/maxresdefault.jpg"
+  video_link: "https://www.youtube.com/watch?v=kzEQNDNaSXA"
+  read_me: "Hi I am testing out submission 1752"
+  project_log:
+  show_public: true
+
+submission_1753:
+  id: 1753
+  milestone_id: 2
+  team_id: 1738
+  published: false
+  created_at: <%= 0.days.from_now.to_s :db %>
+  updated_at: <%= 0.days.from_now.to_s :db %>
+  poster_link:
+  video_link:
+  read_me: "Hi I am testing out submission 1753"
+  project_log:
+  show_public: true
+
+submission_1754:
+  id: 1754
+  milestone_id: 3
+  team_id: 1738
+  published: false
+  created_at: <%= 0.days.from_now.to_s :db %>
+  updated_at: <%= 0.days.from_now.to_s :db %>
+  poster_link:
+  video_link:
+  read_me: "Hi I am testing out submission 1754"
+  project_log:
+  show_public: true
+
+submission_1755:
+  id: 1755
+  milestone_id: 2
+  team_id: 1740
+  published: false
+  created_at: <%= 0.days.from_now.to_s :db %>
+  updated_at: <%= 0.days.from_now.to_s :db %>
+  poster_link: "http://breadnmolasses.com/wp-content/uploads/2009/04/1755-logo-petit-300x260.jpg"
+  video_link: "https://www.youtube.com/watch?v=__pmy8a17pM"
+  read_me: "Hi I am testing out submission 1755"
+  project_log:
+  show_public: true


### PR DESCRIPTION
Fixes #609.

- [x] Disable modal button if there is no submissions previously from the team
- [x] Do not show video / poster when there is no link provided
- [x] Ensure that the `cross` for the modal works for all
- [x] Edit modal styling to be responsive and for all sizes
- [x] Refactoring of code and styling
- [x] Add fixture data for `Submissions.yml` for testing

Behaviour shown below:
![project modal better](https://user-images.githubusercontent.com/28522090/42964869-f0c7a692-8bca-11e8-8048-85f4ce395c71.gif)
