### PR TITLE
#634 Fix layout order for team projects

### DIFF
--- a/app/views/public_views/public_projects/_public_teams_table.html.erb
+++ b/app/views/public_views/public_projects/_public_teams_table.html.erb
@@ -29,6 +29,9 @@
   </div>
   <% locals[:selected_teams].each_with_index do |team, idx| %>
   <!-- The Project Profile -->
+  <% if (idx % 3 == 0) %>
+    <div class="row"></div>
+  <% end %>
   <div class="col-md-4 portfolio-item">
     <a role="button" onclick="createModalBox(<%= team.team_name %>)" id="button_<%= team.team_name %>">
       <% if !team.poster_link.blank? %>


### PR DESCRIPTION
Fixes #634 

This is due to bootstrap not aligning properly caused by floating point error. More information for the fix can be found here https://stackoverflow.com/questions/22866109/bootstrap-columns-not-aligning-correctly

There is not enough data to ensure a complete fix. But after trying the current method. This is the before and after of the teams. Need @chowyb to double check on the server

Before:

![screen shot 2018-07-20 at 3 55 38 am](https://user-images.githubusercontent.com/28522090/42966800-d6394118-8bd0-11e8-83b0-dcfcd2cd7e87.png)

After:

![screen shot 2018-07-20 at 3 50 36 am](https://user-images.githubusercontent.com/28522090/42966713-a7eb3c1c-8bd0-11e8-9610-1171e33203fe.png)