### PR TITLE
#572 Mentor feedback form

### DIFF
--- a/app/assets/javascripts/mentor_comments.js
+++ b/app/assets/javascripts/mentor_comments.js
@@ -1,0 +1,1 @@
+'use strict';

--- a/app/controllers/mentor_comments_controller.rb
+++ b/app/controllers/mentor_comments_controller.rb
@@ -1,0 +1,106 @@
+# MentorCommentController: manage actions related to mentor comments
+#   new:    view to create a mentor comments
+#   create: create a mentor comments
+#   edit:   view to edit a mentor comments
+#   update: update a mentor comments
+class MentorCommentsController < ApplicationController
+    def new
+      mentor = Mentor.find(params[:mentor_id]) || (record_not_found && return)
+      !authenticate_user(true, false) && return
+      @page_title = t('.page_title')
+      @mentor_comment = MentorComment.new
+      teams = []
+      mentor.teams.each do |team|
+        teams.append(team)
+      end
+      milestone = Milestone.find_by(name: 'Milestone 3', cohort: teams[0].cohort)
+      feedback_template = SurveyTemplate.find_by(
+        milestone_id: milestone.id,
+        survey_type: SurveyTemplate.survey_types[:survey_type_mentor_comments]
+      )
+      render locals: {
+        teams: teams,
+        feedback_template: feedback_template
+      }
+    end
+  
+    def create
+      !authenticate_user(true, false) && return
+      if create_or_update_feedback_and_responses
+        redirect_to home_path, flash: {
+          success: t('.success_message')
+        }
+      else
+        redirect_to home_path, flash: {
+          danger: t('.failure_message',
+                    error_message: @feedback.errors.full_messages.join(', '))
+        }
+      end
+    end
+  
+    def edit
+      mentor = Mentor.find(params[:mentor_id]) || (record_not_found && return)
+      !authenticate_user(true, false) && return
+      @page_title = t('.page_title')
+      @mentor_comment = MentorComment.find(params[:id])
+      teams = []
+      mentor.teams.each do |team|
+        teams.append(team.team)
+      end
+      milestone = Milestone.find_by(name: 'Milestone 3', cohort: team.cohort)
+      feedback_template = SurveyTemplate.find_by(
+        milestone_id: milestone.id,
+        survey_type: SurveyTemplate.survey_types[:survey_type_mentor_comments]
+      )
+      render locals: {
+        teams: teams,
+        feedback_template: feedback_template
+      }
+    end
+  
+    def update
+      mentor = Mentor.find(params[:mentor_id]) || (record_not_found && return)
+      !authenticate_user(true, false) && return
+      @mentor_comment = MentorComment.find(params[:id])
+      if create_or_update_feedback_and_responses(@mentor_commentdback)
+        redirect_to home_path, flash: {
+          success: t('.success_message')
+        }
+      else
+        redirect_to home_path, flash: {
+          danger: t('.failure_message',
+                    error_message: @mentor_comment.errors.full_messages.join(', '))
+        }
+      end
+    end
+  
+    private
+  
+    def mentor_comment_params
+      mentor_comment_ps = params.require(:mentor_comment).permit!
+      mentor_comment_ps[:mentor_id] = params[:mentor_id]
+      mentor_comment_ps = {} if mentor_comment_ps[:edit] == 'on'
+      mentor_comment_ps.except!(:feedback_to_team)
+      mentor_comment_ps
+    end
+  
+    def questions_params
+      params.require(:questions).permit!
+    end
+  
+    def create_or_update_feedback_and_responses(mentor_comment = nil)
+      print "-------------------"
+      print mentor_comment_params
+      if mentor_comment.nil?
+        @mentor_comment = MentorComment.new(mentor_comment_params)
+        mentor_comment_template = SurveyTemplate.all[0]
+        @mentor_comment.survey_template_id = mentor_comment_template.id
+      else
+        mentor_comment.update(mentor_comment_params)
+        @mentor_comment = mentor_comment
+      end
+      @mentor_comment.response_content = questions_params.to_json
+      @mentor_comment.save ? @mentor_comment : nil
+    end
+  end
+  

--- a/app/controllers/mentor_comments_controller.rb
+++ b/app/controllers/mentor_comments_controller.rb
@@ -6,7 +6,7 @@
 class MentorCommentsController < ApplicationController
     def new
       mentor = Mentor.find(params[:mentor_id]) || (record_not_found && return)
-      !authenticate_user(true, false) && return
+      !authenticate_user(true, false, [mentor.user]) && return
       @page_title = t('.page_title')
       @mentor_comment = MentorComment.new
       teams = []
@@ -25,7 +25,8 @@ class MentorCommentsController < ApplicationController
     end
   
     def create
-      !authenticate_user(true, false) && return
+      mentor = Mentor.find(params[:mentor_id]) || (record_not_found && return)
+      !authenticate_user(true, false, [mentor.user]) && return
       if create_or_update_feedback_and_responses
         redirect_to home_path, flash: {
           success: t('.success_message')
@@ -40,7 +41,7 @@ class MentorCommentsController < ApplicationController
   
     def edit
       mentor = Mentor.find(params[:mentor_id]) || (record_not_found && return)
-      !authenticate_user(true, false) && return
+      !authenticate_user(true, false, [mentor.user]) && return
       @page_title = t('.page_title')
       @mentor_comment = MentorComment.find(params[:id])
       teams = []
@@ -60,7 +61,7 @@ class MentorCommentsController < ApplicationController
   
     def update
       mentor = Mentor.find(params[:mentor_id]) || (record_not_found && return)
-      !authenticate_user(true, false) && return
+      !authenticate_user(true, false, [mentor.user]) && return
       @mentor_comment = MentorComment.find(params[:id])
       if create_or_update_feedback_and_responses(@mentor_commentdback)
         redirect_to home_path, flash: {
@@ -89,11 +90,9 @@ class MentorCommentsController < ApplicationController
     end
   
     def create_or_update_feedback_and_responses(mentor_comment = nil)
-      print "-------------------"
-      print mentor_comment_params
       if mentor_comment.nil?
         @mentor_comment = MentorComment.new(mentor_comment_params)
-        mentor_comment_template = SurveyTemplate.all[0]
+        mentor_comment_template = SurveyTemplate.all[2]
         @mentor_comment.survey_template_id = mentor_comment_template.id
       else
         mentor_comment.update(mentor_comment_params)

--- a/app/controllers/mentor_comments_controller.rb
+++ b/app/controllers/mentor_comments_controller.rb
@@ -92,8 +92,8 @@ class MentorCommentsController < ApplicationController
     def create_or_update_feedback_and_responses(mentor_comment = nil)
       if mentor_comment.nil?
         @mentor_comment = MentorComment.new(mentor_comment_params)
-        mentor_comment_template = SurveyTemplate.all[2]
-        @mentor_comment.survey_template_id = mentor_comment_template.id
+        @mentor_comment_template = SurveyTemplate.find_by(survey_type: SurveyTemplate.survey_types[:survey_type_mentor_comments])
+        @mentor_comment.survey_template_id = @mentor_comment_template.id
       else
         mentor_comment.update(mentor_comment_params)
         @mentor_comment = mentor_comment

--- a/app/controllers/received_mentor_comments_controller.rb
+++ b/app/controllers/received_mentor_comments_controller.rb
@@ -1,0 +1,23 @@
+# ReceivedFeedbacksController: manage actions related received_feedbacks
+#   index: list all received feedbacks
+class ReceivedMentorCommentsController < ApplicationController
+  def index
+    !can_view_received_feedbacks_page && return
+    @mentor_comments= MentorComment.where(target_team_id: params[:team_id])
+    @page_title = t('.page_title')
+  end
+
+  private
+
+  def can_view_received_feedbacks_page
+    if params[:team_id]
+      @team = Team.find(params[:team_id]) ||
+              (record_not_found && return)
+      !authenticate_user(true, false, @team.get_relevant_users(false, false)) &&
+        (return false)
+    else
+      raise ActionController::RoutingError.new(t('application.path_not_found_message'))
+    end
+    true
+  end
+end

--- a/app/models/mentor_comment.rb
+++ b/app/models/mentor_comment.rb
@@ -1,0 +1,19 @@
+# MentorComment: MentorComment modeling
+class MentorComment < ActiveRecord::Base
+    validates :mentor_id, presence: true
+    validates :survey_template_id, presence: true
+    validates :target_team_id, uniqueness: {
+      scope: :mentor_id,
+      message: ' cannot submit duplicated feedback'
+    }, if: :target_type_team?
+  
+    belongs_to :mentor
+    belongs_to :target_team, foreign_key: :target_team_id, class_name: Team
+    belongs_to :survey_template
+  
+    enum target_type: [:target_type_team]
+  
+    def get_response_for_question(question_id)
+      response_content[question_id.to_s] unless response_content.blank?
+    end
+  end

--- a/app/models/survey_template.rb
+++ b/app/models/survey_template.rb
@@ -8,5 +8,5 @@ class SurveyTemplate < ActiveRecord::Base
   }
 
   enum survey_type: [:survey_type_submission, :survey_type_peer_evaluation,
-                     :survey_type_feedback, :survey_type_registration]
+                     :survey_type_feedback, :survey_type_registration, :survey_type_mentor_comments]
 end

--- a/app/views/mentor_comments/_mentor_comment_form.html.erb
+++ b/app/views/mentor_comments/_mentor_comment_form.html.erb
@@ -12,12 +12,6 @@
     <% if locals[:is_new] %>
         <div class="group">
           <%= f.input :target_team_id, collection: locals[:teams].map {|a| [a.team_name, a.id]}, include_blank: false %>
-          <div class="checkbox">
-            <label>
-              <input type="checkbox" checked="checked" name="feedback[feedback_to_team]">
-              Feedback to peer teams
-            </label>
-          </div>
         </div>
     <% else %>
         <input type="hidden" name="feedback[edit]" value="on">

--- a/app/views/mentor_comments/_mentor_comment_form.html.erb
+++ b/app/views/mentor_comments/_mentor_comment_form.html.erb
@@ -1,0 +1,26 @@
+<%= simple_form_for(locals[:mentor_comment], wrapper: :vertical_form,
+                    url: {action: (locals[:is_new] ? 'create' : 'update')}) do |f| %>
+    <%= f.error_notification %>
+    <div class="form-group">
+      <div class="text-muted"><%= locals[:feedback_template].instruction.html_safe %></div>
+    </div>
+    <% locals[:feedback_template].questions.each do |question| %>
+        <%= render 'questions/question_template',
+                   locals: {question: question,
+                            question_response: locals[:mentor_comment].get_response_for_question(question.id)} %>
+    <% end %>
+    <% if locals[:is_new] %>
+        <div class="group">
+          <%= f.input :target_team_id, collection: locals[:teams].map {|a| [a.team_name, a.id]}, include_blank: false %>
+          <div class="checkbox">
+            <label>
+              <input type="checkbox" checked="checked" name="feedback[feedback_to_team]">
+              Feedback to peer teams
+            </label>
+          </div>
+        </div>
+    <% else %>
+        <input type="hidden" name="feedback[edit]" value="on">
+    <% end %>
+    <%= f.button :submit_centred, class: 'btn-success' %>
+<% end %>

--- a/app/views/mentor_comments/_view_mentor_comment.html.erb
+++ b/app/views/mentor_comments/_view_mentor_comment.html.erb
@@ -1,0 +1,12 @@
+<div class="form" action="#">
+  <div class="form-group">
+    <div class="text-muted"><%= t('mentor_comment.instruction_omitted_message') %></div>
+  </div>
+  <br>
+  <% locals[:feedback].survey_template.questions.order('questions.order ASC').each do |question| %>
+      <%= render 'questions/question_template',
+                 locals: {question: question,
+                          question_response: locals[:mentor_comment].get_response_for_question(question.id),
+                          view_template: true} %>
+  <% end %>
+</div>

--- a/app/views/mentor_comments/_view_mentor_comment.html.erb
+++ b/app/views/mentor_comments/_view_mentor_comment.html.erb
@@ -3,7 +3,7 @@
     <div class="text-muted"><%= t('mentor_comment.instruction_omitted_message') %></div>
   </div>
   <br>
-  <% locals[:feedback].survey_template.questions.order('questions.order ASC').each do |question| %>
+  <% locals[:mentor_comment].survey_template.questions.order('questions.order ASC').each do |question| %>
       <%= render 'questions/question_template',
                  locals: {question: question,
                           question_response: locals[:mentor_comment].get_response_for_question(question.id),

--- a/app/views/mentor_comments/edit.html.erb
+++ b/app/views/mentor_comments/edit.html.erb
@@ -1,0 +1,13 @@
+<% content_for :main_content do %>
+    <% javascript 'mentor_comments.js' %>
+    <div class="panel panel-info">
+      <div class="panel-heading">
+        <h3 class="text-center">Edit feedback</h3>
+      </div>
+      <div class="panel-body">
+        <%= render 'mentor_comment_form', locals: {mentor_comment: @mentor_comment, teams: teams,
+                                              feedback_template: feedback_template,
+                                              is_new: false} %>
+      </div>
+    </div>
+<% end %>

--- a/app/views/mentor_comments/new.html.erb
+++ b/app/views/mentor_comments/new.html.erb
@@ -1,0 +1,13 @@
+<% content_for :main_content do %>
+    <% javascript 'mentor_comments.js' %>
+    <div class="panel panel-info">
+      <div class="panel-heading">
+        <h3 class="text-center">Create feedback</h3>
+      </div>
+      <div class="panel-body">
+        <%= render 'mentor_comment_form', locals: {mentor_comment: @mentor_comment, teams: teams,
+                                              feedback_template: feedback_template,
+                                              is_new: true} %>
+      </div>
+    </div>
+<% end %>

--- a/app/views/mentors/_mentor_view.html.erb
+++ b/app/views/mentors/_mentor_view.html.erb
@@ -19,6 +19,12 @@
             View milestones submitted by teams
           </a>
         </li>
+        <li role="presentation">
+          <a href="#mentor-comments-panel" aria-controls="mentor-comments-panel"
+            role="tab" data-toggle="tab">
+            Give feedback to teams
+          </a>
+        </li>
       </ul>
       <div class="tab-content">
         <div role="tabpanel" class="tab-pane fade in active" id="teams-panel">
@@ -48,12 +54,6 @@
                         <td>
                           <%= l team_submission.updated_at %>
                         </td>
-                        <td>
-                          <a href="<%= new_mentor_mentor_comment_path(locals[:mentor].id) %>"
-                          class="btn btn-default">
-                            Start Evaluation
-                          </a>
-                        </td>
                       </tr>
                     <% else %>
                       <tr>
@@ -80,6 +80,15 @@
             </table>
           </div>
           <% end %>
+        </div>
+        <div role="tabpanel" class="tab-pane fade" id="mentor-comments-panel">
+          <br>
+          <td>
+            <a href="<%= new_mentor_mentor_comment_path(locals[:mentor].id) %>"
+            class="btn btn-success">
+              Give feedback
+            </a>
+          </td>
         </div>
       </div>
     </div>

--- a/app/views/mentors/_mentor_view.html.erb
+++ b/app/views/mentors/_mentor_view.html.erb
@@ -48,6 +48,12 @@
                         <td>
                           <%= l team_submission.updated_at %>
                         </td>
+                        <td>
+                          <a href="<%= new_mentor_mentor_comment_path(locals[:mentor].id) %>"
+                          class="btn btn-default">
+                            Start Evaluation
+                          </a>
+                        </td>
                       </tr>
                     <% else %>
                       <tr>
@@ -73,11 +79,11 @@
                 </tbody>
             </table>
           </div>
+          <% end %>
         </div>
       </div>
     </div>
     <hr>
-    <% end %>
     <br><hr>
     You can send emails to your students via
     <%= link_to 'General Mailing', general_mailing_mentor_path(locals[:mentor].id), class: 'btn btn-success' %>

--- a/app/views/received_mentor_comments/index.html.erb
+++ b/app/views/received_mentor_comments/index.html.erb
@@ -1,0 +1,26 @@
+<% content_for :main_content do %>
+    <% javascript 'received_feedbacks.js' %>
+    <div class="panel panel-default">
+      <div class="panel-heading">
+        <h1>
+          Comments from mentor for <%= @team.team_name %>
+        </h1>
+      </div>
+      <div class="panel-body">
+        <% if @mentor_comments.nil? or @mentor_comments.length == 0 %>
+            No feedback available
+        <% end %>
+        <% @mentor_comments.each_with_index do |mentor_comment, idx| %>
+            <div class="panel panel-primary">
+              <div class="panel-heading">
+                <label>Feedback <%= idx + 1 %></label>
+              </div>
+              <div class="panel-body">
+                <%= render 'mentor_comments/view_mentor_comment', locals: {mentor_comment: mentor_comment,
+                                                                           team_id: @team.id} %>
+              </div>
+            </div>
+        <% end %>
+      </div>
+    </div>
+<% end %>

--- a/app/views/teams/show.html.erb
+++ b/app/views/teams/show.html.erb
@@ -57,6 +57,12 @@
                 More information
               </a>
             </li>
+            <li role="presentation">
+              <a href="#mentor-comments-panel" aria-controls="mentor-comments-panel"
+                role="tab" data-toggle="tab">
+                Comments from mentor
+              </a>
+            </li>
           <% end %>
         </ul>
         <div class="tab-content">
@@ -136,6 +142,13 @@
                          locals: {team: @team, milestones: milestones,
                                   eval_ratings_hash: @team.get_average_evaluation_ratings,
                                   feedback_ratings_hash: @team.get_average_feedback_ratings} %>
+            </div>
+            <div role="tabpanel" class="tab-pane fade" id="mentor-comments-panel">
+              <div class="text-center">
+                You can view comments from your mentor
+                <a href="<%= milestone_team_received_mentor_comments_path(3, @team.id) %>"
+                  class="btn btn-success">here</a>
+              </div>
             </div>
           <% end %>
         </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -74,6 +74,7 @@ Rails.application.routes.draw do
       resources :peer_evaluations, only: [:new, :create, :edit, :update, :show]
       resources :received_evals, only: [:index]
       resources :received_feedbacks, only: [:index]
+      resources :received_mentor_comments, only: [:index]
     end
     resources :advisers, only: [:show] do
       resources :received_feedbacks, only: [:index]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,6 +58,11 @@ Rails.application.routes.draw do
   end
   resources :facilitators, only: [:index, :new, :create, :show, :destroy]
   resources :tutors, only: [:index, :new, :create, :show, :destroy]
+
+  resources :mentors do
+    resources :mentor_comments, only: [:new, :create, :edit, :update]
+  end
+  
   resources :teams do
     resources :feedbacks, only: [:new, :create, :edit, :update]
   end

--- a/db/migrate/20180721170911_create_mentor_comments.rb
+++ b/db/migrate/20180721170911_create_mentor_comments.rb
@@ -1,0 +1,14 @@
+class CreateMentorComments < ActiveRecord::Migration
+  def change
+    create_table :mentor_comments do |t|
+      t.references :mentor, index: true
+      t.references :survey_template, index: true
+      t.json :response_content
+      t.integer :target_team_id, index: true
+      t.timestamps null: false
+    end
+    add_foreign_key :mentor_comments, :mentors
+    add_foreign_key :mentor_comments, :survey_templates
+    add_foreign_key :mentor_comments, :teams, column: :target_team_id
+  end
+end


### PR DESCRIPTION
Added Page for mentors to provide comments on the teams and overall experience as discussed in #572 
A new table is added, so db:migrate will need to be run first.
Mentors can create their comments here:
![image](https://user-images.githubusercontent.com/13115806/43212796-8db31b1c-9067-11e8-8c13-bb036852a6ff.png)
And students will be able to view their comments from their team page here:
![image](https://user-images.githubusercontent.com/13115806/43212860-b1072266-9067-11e8-8c7f-b6dd77d196a7.png)