### PR TITLE
#555 unable to give feedback to advisors

### DIFF
--- a/app/controllers/students_controller.rb
+++ b/app/controllers/students_controller.rb
@@ -50,7 +50,8 @@ class StudentsController < RolesController
       team_evaluateds_submissions: @role.team.get_others_submissions,
       team_evaluations: @role.team.get_own_evaluations_for_others,
       team_evaluators_evaluations: @role.team.get_evaluations_for_own_team,
-      team_feedbacks: @role.team.get_feedbacks_for_others
+      team_feedbacks: @role.team.get_feedbacks_for_others,
+      adviser_feedbacks: @role.team.get_feedbacks_for_adviser
     }
   end
 

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -189,6 +189,13 @@ class Team < ActiveRecord::Base
     feedbacks_hash
   end
 
+  def get_feedbacks_for_adviser
+    feedbacks_hash = {}
+    feedbacks_hash[adviser.user_id] = Feedback.find_by(
+      team_id: id, adviser_id: adviser.user_id)
+    feedbacks_hash
+  end
+
   def get_average_evaluation_ratings
     ratings_hash = {}
     peer_evaluations_hash = get_evaluations_for_own_team

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -191,7 +191,7 @@ class Team < ActiveRecord::Base
 
   def get_feedbacks_for_adviser
     feedbacks_hash = {}
-    if !adviser.user_id.blank?
+    if !adviser_id.blank?
       feedbacks_hash[adviser.user_id] = Feedback.find_by(
         team_id: id, adviser_id: adviser.user_id)
     end

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -191,8 +191,10 @@ class Team < ActiveRecord::Base
 
   def get_feedbacks_for_adviser
     feedbacks_hash = {}
-    feedbacks_hash[adviser.user_id] = Feedback.find_by(
-      team_id: id, adviser_id: adviser.user_id)
+    if !adviser.user_id.blank?
+      feedbacks_hash[adviser.user_id] = Feedback.find_by(
+        team_id: id, adviser_id: adviser.user_id)
+    end
     feedbacks_hash
   end
 

--- a/app/views/students/_student_submit_feedbacks.html.erb
+++ b/app/views/students/_student_submit_feedbacks.html.erb
@@ -38,7 +38,7 @@
           Active
         </td>
         <td>
-          <% if (adviser_feedback = locals[:team_feedbacks][:adviser]) %>
+          <% if (adviser_feedback = locals[:adviser_feedbacks][locals[:team].adviser_id]) %>
             <a class="btn btn-success" href="<%= edit_team_feedback_path(locals[:team].id, adviser_feedback.id) %>">
               Edit feedback
             </a>

--- a/app/views/students/_student_submit_feedbacks.html.erb
+++ b/app/views/students/_student_submit_feedbacks.html.erb
@@ -11,18 +11,20 @@
           </td>
           <td>
             <% if evaluator.evaluator.has_dropped %>
-                <span style="color: #ff0000;">Dropped</span>
+              <span style="color: #ff0000;">Dropped</span>
             <% else %>
-                Active
+              Active
             <% end %>
           </td>
           <td>
             <% if (team_feedback = locals[:team_feedbacks][evaluator.id]) %>
               <a class="btn btn-success" href="<%= edit_team_feedback_path(locals[:team].id, team_feedback.id) %>">
-                Edit feedback</a>
+                Edit feedback
+              </a>
             <% else %>
               <a class="btn btn-primary" href="<%= new_team_feedback_path(locals[:team].id) %>">
-                Submit feedback</a>
+                Submit feedback
+              </a>
             <% end %>
           </td>
         </tr>

--- a/app/views/students/_student_submit_feedbacks.html.erb
+++ b/app/views/students/_student_submit_feedbacks.html.erb
@@ -40,10 +40,12 @@
         <td>
           <% if (adviser_feedback = locals[:team_feedbacks][:adviser]) %>
             <a class="btn btn-success" href="<%= edit_team_feedback_path(locals[:team].id, adviser_feedback.id) %>">
-              Edit feedback</a>
+              Edit feedback
+            </a>
           <% else %>
             <a class="btn btn-primary" href="<%= new_team_feedback_path(locals[:team].id) %>">
-              Submit feedback</a>
+              Create feedback
+            </a>
           <% end %>
         </td>
       </tr>

--- a/app/views/students/_student_with_team.html.erb
+++ b/app/views/students/_student_with_team.html.erb
@@ -87,7 +87,8 @@
             team: locals[:student].team,
             milestones: locals[:role_data][:milestones],
             evaluators: locals[:role_data][:evaluators],
-            team_feedbacks: locals[:role_data][:team_feedbacks]
+            team_feedbacks: locals[:role_data][:team_feedbacks],
+            adviser_feedbacks: locals[:role_data][:adviser_feedbacks]
           } %>
         </div>
         <div role="tabpanel" class="tab-pane fade" id="preview-survey-template-panel">

--- a/test/fixtures/students.yml
+++ b/test/fixtures/students.yml
@@ -1,12 +1,45 @@
 # fixtures for students cohort 2018
-<% (10..20).each do |n| %>
+<% (10..11).each do |n| %>
+stu_<%= n %>:
+  id: <%= n %>
+  user_id: <%= n %>
+  created_at: <%= 0.days.from_now.to_s :db %>
+  updated_at: <%= 0.days.from_now.to_s :db %>
+  team_id: 31
+  is_pending: FALSE
+  cohort: 2018
+<% end %>
+
+<% (12..13).each do |n| %>
+stu_<%= n %>:
+  id: <%= n %>
+  user_id: <%= n %>
+  created_at: <%= 0.days.from_now.to_s :db %>
+  updated_at: <%= 0.days.from_now.to_s :db %>
+  team_id: 32
+  is_pending: FALSE
+  cohort: 2018
+<% end %>
+
+<% (14..15).each do |n| %>
+stu_<%= n %>:
+  id: <%= n %>
+  user_id: <%= n %>
+  created_at: <%= 0.days.from_now.to_s :db %>
+  updated_at: <%= 0.days.from_now.to_s :db %>
+  team_id: 33
+  is_pending: FALSE
+  cohort: 2018
+<% end %>
+
+<% (16..20).each do |n| %>
 stu_<%= n %>:
   id: <%= n %>
   user_id: <%= n %>
   created_at: <%= 0.days.from_now.to_s :db %>
   updated_at: <%= 0.days.from_now.to_s :db %>
   team_id:
-  is_pending: TRUE
+  is_pending: FALSE
   cohort: 2018
 <% end %>
 

--- a/test/fixtures/teams.yml
+++ b/test/fixtures/teams.yml
@@ -1,3 +1,59 @@
+team_31:
+  id: 31
+  adviser_id: 6
+  mentor_id: 21
+  created_at: <%= 0.days.from_now.to_s :db %>
+  updated_at: <%= 0.days.from_now.to_s :db %>
+  team_name: "I am team 31"
+  has_dropped: false
+  project_level: 0
+  is_pending: false
+  cohort: 2018
+  poster_link: "http://beardstyle.net/wp-content/uploads/2016/06/girls-with-mustaches-6.jpg"
+  video_link:
+
+team_32:
+  id: 32
+  adviser_id: 6
+  mentor_id: 21
+  created_at: <%= 0.days.from_now.to_s :db %>
+  updated_at: <%= 0.days.from_now.to_s :db %>
+  team_name: "I am team 32"
+  has_dropped: false
+  project_level: 0
+  is_pending: false
+  cohort: 2018
+  poster_link: "http://beardstyle.net/wp-content/uploads/2016/06/girls-with-mustaches-6.jpg"
+  video_link:
+
+team_33:
+  id: 33
+  adviser_id: 7
+  mentor_id: 22
+  created_at: <%= 0.days.from_now.to_s :db %>
+  updated_at: <%= 0.days.from_now.to_s :db %>
+  team_name: "I am team 33"
+  has_dropped: false
+  project_level: 1
+  is_pending: false
+  cohort: 2018
+  poster_link: "http://beardstyle.net/wp-content/uploads/2016/06/girls-with-mustaches-6.jpg"
+  video_link:
+
+team_34:
+  id: 34
+  adviser_id: 7
+  mentor_id: 22
+  created_at: <%= 0.days.from_now.to_s :db %>
+  updated_at: <%= 0.days.from_now.to_s :db %>
+  team_name: "I am team 34"
+  has_dropped: false
+  project_level: 1
+  is_pending: false
+  cohort: 2018
+  poster_link: "http://beardstyle.net/wp-content/uploads/2016/06/girls-with-mustaches-6.jpg"
+  video_link:
+    
 # fixtures for teams cohort 2017
 # 1731-1734 vostok, 1735-1737 gemini, 1738-1740 apollo_11
 <% (1731..1732).each do |n| %>

--- a/test/fixtures/teams.yml
+++ b/test/fixtures/teams.yml
@@ -53,7 +53,21 @@ team_34:
   cohort: 2018
   poster_link: "http://beardstyle.net/wp-content/uploads/2016/06/girls-with-mustaches-6.jpg"
   video_link:
-    
+
+team_35:
+  id: 35
+  adviser_id:
+  mentor_id: 22
+  created_at: <%= 0.days.from_now.to_s :db %>
+  updated_at: <%= 0.days.from_now.to_s :db %>
+  team_name: "I am team 35"
+  has_dropped: false
+  project_level: 1
+  is_pending: false
+  cohort: 2018
+  poster_link: "http://beardstyle.net/wp-content/uploads/2016/06/girls-with-mustaches-6.jpg"
+  video_link:
+
 # fixtures for teams cohort 2017
 # 1731-1734 vostok, 1735-1737 gemini, 1738-1740 apollo_11
 <% (1731..1732).each do |n| %>


### PR DESCRIPTION
Fixes #555 

Following the fixture data below. I managed to reproduce the problem on local.

It seems that the first time a student submit the feedback to the advisor, it works with a successful message. Thereafter, the second attempt the user tries to create the feedback, the advisor will receive an error message. (The 23 seconds gif below explains this situation)

![saving feedback](https://user-images.githubusercontent.com/28522090/43678771-0dbb4af0-984c-11e8-8eeb-33270ef96ea9.gif)

Upon submitting the feedback initially, the data submitted is saved in the database as shown below. Hence, there is an error message when the user tries to save again.

<img width="1278" alt="screen shot 2018-08-05 at 1 08 49 am" src="https://user-images.githubusercontent.com/28522090/43678780-3b59c1d0-984c-11e8-8d20-72c20cdb3525.png">

I believe that the second time the user should see `Edit Feedback` instead of `Submit Feedback` as the feedback is already created in the database in the first attempt. That is why only some teams face this problem of not being able to save and demo team has no problem submitting the feedbacks.

![screen shot 2018-08-05 at 1 10 55 am](https://user-images.githubusercontent.com/28522090/43678815-9c2d6caa-984c-11e8-9bd4-8414ab5992b4.png)

I will aim to submit a fully functional PR by tomorrow!