### PR TITLE
#555 student cannot give feedback to advisers

### DIFF
--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -192,8 +192,8 @@ class Team < ActiveRecord::Base
   def get_feedbacks_for_adviser
     feedbacks_hash = {}
     if !adviser_id.blank?
-      feedbacks_hash[adviser.user_id] = Feedback.find_by(
-        team_id: id, adviser_id: adviser.user_id)
+      feedbacks_hash[adviser.id] = Feedback.find_by(
+        team_id: id, adviser_id: adviser.id)
     end
     feedbacks_hash
   end

--- a/test/fixtures/advisers.yml
+++ b/test/fixtures/advisers.yml
@@ -2,7 +2,7 @@
 <% (6..9).each do |n| %>
 admin_<%= n %>:
   id: <%= n %>
-  user_id: <%= n %> 
+  user_id: <%= n + 100 %>
   created_at: <%= 0.days.from_now.to_s :db %>
   updated_at: <%= 0.days.from_now.to_s :db %>
   cohort: 2018	
@@ -12,7 +12,7 @@ admin_<%= n %>:
 <% (1706..1709).each do |n| %>
 admin_<%= n %>:
   id: <%= n %>
-  user_id: <%= n %> 
+  user_id: <%= n + 100 %> 
   created_at: <%= 0.days.from_now.to_s :db %>
   updated_at: <%= 0.days.from_now.to_s :db %>
   cohort: 2017	


### PR DESCRIPTION
Fixes #555 

Upon looking at the data files online, it seems that the adviser `user_id` is different from `id` shown in the image below. However, in the fixture data, user_id is same as id causing the difference in the problem.
![screen shot 2018-08-08 at 5 55 03 pm](https://user-images.githubusercontent.com/28522090/43830852-e1776f32-9b34-11e8-8d13-a1753ea373cb.png)

Hence I tried to differentiate the user_id and id for adviser in local server and production server. It can be solved by simply using `id` instead of `user_id` to find the feedback.

It will show `Edit feedback` instead of `Create feedback now`
![screen shot 2018-08-08 at 6 04 28 pm](https://user-images.githubusercontent.com/28522090/43831078-8c570430-9b35-11e8-89e7-08dfe39166a5.png)
