### PR TITLE
Fix advisers.yml

### DIFF
--- a/test/fixtures/advisers.yml
+++ b/test/fixtures/advisers.yml
@@ -2,18 +2,18 @@
 <% (6..9).each do |n| %>
 admin_<%= n %>:
   id: <%= n %>
-  user_id: <%= n + 100 %>
+  user_id: <%= n %>
   created_at: <%= 0.days.from_now.to_s :db %>
   updated_at: <%= 0.days.from_now.to_s :db %>
-  cohort: 2018	
+  cohort: 2018
 <% end %>
 
 #cohort 2017
 <% (1706..1709).each do |n| %>
 admin_<%= n %>:
   id: <%= n %>
-  user_id: <%= n + 100 %> 
+  user_id: <%= n %>
   created_at: <%= 0.days.from_now.to_s :db %>
   updated_at: <%= 0.days.from_now.to_s :db %>
-  cohort: 2017	
+  cohort: 2017
 <% end %>


### PR DESCRIPTION
Steps to reproduce the bug if you are not on this branch:
1) Re-initialize fixtures.
2) Go to 'projects' page.
3) It should display an error page stating that `adviser.user` is of NIL Class.

This is caused by user_id in adviser.yml pointing to non-existent user. Let me know if there are any issues!

Also I am not sure whether to make a PR to `master` or to `dev` branch. Do advise!