### PR TITLE
Fix missing default image for ealier cohorts under Vostok

### DIFF
--- a/app/views/public_views/public_projects/_public_teams_table.html.erb
+++ b/app/views/public_views/public_projects/_public_teams_table.html.erb
@@ -35,7 +35,7 @@
         <%= link_to image_tag(team.poster_link, size: "200", alt: "Team's Poster Link is not in image form",
           title: "Click to view an enlarged version of this image."), team.poster_link %>
       <% elsif locals[:selected_type] == 'Vostok' %>
-        <%= image_tag("Vostok_Icon.png", size: "200", class: 'img-rounded inactive_link') %>
+        <%= image_tag("Vostok_Icon.jpg", size: "200", class: 'img-rounded inactive_link') %>
       <% elsif locals[:selected_type] == 'Project Gemini' %>
         <%= image_tag("Project_Gemini_Icon.png", size: "200", class: 'img-rounded inactive_link') %>
       <% elsif locals[:selected_type] == 'Apollo 11' %>


### PR DESCRIPTION
Fix #647

I change the image filename from Vostok_Icon.png to Vostok_Icon.jpg as the assets image is kept as jpg instead of png.

Below are the screenshot to show that it is working on earlier cohorts

![screenshot 2019-02-02 at 13 45 59](https://user-images.githubusercontent.com/5901764/52160508-84e3b480-26f1-11e9-8454-bdeff32b295c.png)
![screenshot 2019-02-02 at 13 46 04](https://user-images.githubusercontent.com/5901764/52160510-8ad99580-26f1-11e9-8564-8b177f513512.png)
![screenshot 2019-02-02 at 13 46 08](https://user-images.githubusercontent.com/5901764/52160511-8b722c00-26f1-11e9-80da-484455a78459.png)
