### PR TITLE
#517 reorder staff entries

### DIFF
--- a/app/views/public_views/public_staff/index.html.erb
+++ b/app/views/public_views/public_staff/index.html.erb
@@ -16,7 +16,7 @@
         <div class="panel-body">
           <% if staff %>
             <div id="facilitators">
-              <%= render 'user_roles', locals: {roles: staff[:facilitators], selected_type: 'Facilitators'} %>
+              <%= render 'user_roles', locals: {roles: staff[:facilitators].reorder(:display_order), selected_type: 'Facilitators'} %>
             </div>
             <div id="advisers">
               <%= render 'user_roles', locals: {roles: staff[:advisers], selected_type: 'Advisers'} %>

--- a/db/migrate/20190506181849_add_display_order_to_facilitators.rb
+++ b/db/migrate/20190506181849_add_display_order_to_facilitators.rb
@@ -1,0 +1,5 @@
+class AddDisplayOrderToFacilitators < ActiveRecord::Migration
+  def change
+    add_column :facilitators, :display_order, :integer, null:false, default:0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,8 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-
-ActiveRecord::Schema.define(version: 20180408182700) do
+ActiveRecord::Schema.define(version: 20190506181849) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -45,9 +44,10 @@ ActiveRecord::Schema.define(version: 20180408182700) do
 
   create_table "facilitators", force: :cascade do |t|
     t.integer  "user_id"
-    t.datetime "created_at", null: false
-    t.datetime "updated_at", null: false
+    t.datetime "created_at",                null: false
+    t.datetime "updated_at",                null: false
     t.integer  "cohort"
+    t.integer  "display_order", default: 0, null: false
   end
 
   add_index "facilitators", ["user_id"], name: "index_facilitators_on_user_id", using: :btree


### PR DESCRIPTION
## Status
PENDING REVIEW

## Migrations
YES

## Description
Adds a new column 'display_order' to the facilitators table. The facilitators table is then reordered by the 'display_order' column, from smallest to biggest. The default display_order value is 0.

## Steps to Test or Reproduce
Run `bundle exec rails db:migrate`, then update a facilitator's display_order to a negative number and it should move to the top.

## Deploy Notes
I was unable to load the fixture data in as described in the [wiki](https://github.com/nusskylab/nusskylab/wiki/Fixture-data), so I haven't been able to test it on existing data. I have only tested it on my manually entered data via adding new users and promoting them to facilitators.
Here is a [pastebin](https://pastebin.com/0N868n1G) of the full trace after running the fixture loading command

## Fixes
* #517 Reordering entries on the staff page
