### PR TITLE
Migrate javascript code to public_project.js

### DIFF
--- a/app/assets/javascripts/public_projects.js
+++ b/app/assets/javascripts/public_projects.js
@@ -1,21 +1,29 @@
 'use strict';
-$(document).ready(function () {
-  $("body").on("click", ".button_team", function(event) {
-    //theoretically doesn't need a closest() call but chrome is weird
-    var clickedButton = $(event.target).closest(".button_team");
-    var team_id = clickedButton.data("team-id");
-    var modal_id = "#modal_" + team_id;
-    var modal = $(modal_id);
-    var span = document.getElementsByClassName("close")[0];
-    console.log("Success!");
-    modal.show();
-    span.onclick = function() {
-      modal.hide();
+function createModalBox(team_id) {
+  var modal = document.getElementById("modal_".concat(team_id));
+  var button = document.getElementById("button_".concat(team_id));
+  var span = modal.getElementsByClassName("close")[0];
+  modal.style.display = "block";
+  // Close using the window close.
+  span.addEventListener('click', function() {
+    closeModal(modal);
+  });
+  // Close modal outside of the modal
+  window.addEventListener('click', function(event) {
+    if (event.target == modal) {
+      closeModal(modal);
     }
-    window.onclick = function(event) {
-      if (event.target == modal) {
-        modal.hide();
-      }
-    }
+  });
+}
+
+function closeModal(modal) {
+  modal.style.display = "none";
+}
+
+document.addEventListener('DOMContentLoaded', function () {
+  Array.from(document.getElementsByClassName("button_team")).forEach(function(element) { 
+    element.addEventListener('click', function() {
+      createModalBox(element.id.slice(element.id.indexOf("_") + 1));
+    });
   });
 });

--- a/app/views/public_views/public_projects/_public_teams_table.html.erb
+++ b/app/views/public_views/public_projects/_public_teams_table.html.erb
@@ -6,43 +6,12 @@
     <meta name="author" content="">
 
     <title>3 Col Portfolio - Start Bootstrap Template</title>
-
     <!-- HTML5 Shim and Respond.js IE8 support of HTML5 elements and media queries -->
     <!-- WARNING: Respond.js doesn't work if you view the page via file:// -->
     <!--[if lt IE 9]>
         <script src="https://oss.maxcdn.com/libs/html5shiv/3.7.0/html5shiv.js"></script>
         <script src="https://oss.maxcdn.com/libs/respond.js/1.4.2/respond.min.js"></script>
     <![endif]-->
-    <script type="text/javascript">
-      function createModalBox(team_id) {
-        var modal = document.getElementById("modal_".concat(team_id));
-        var button = document.getElementById("button_".concat(team_id));
-        var span = modal.getElementsByClassName("close")[0];
-        modal.style.display = "block";
-        // Close using the window close.
-        span.addEventListener('click', function() {
-          closeModal(modal);
-        });
-        // Close modal outside of the modal
-        window.addEventListener('click', function(event) {
-          if (event.target == modal) {
-            closeModal(modal);
-          }
-        });
-      }
-      
-      function closeModal(modal) {
-        modal.style.display = "none";
-      }
-
-      document.addEventListener('DOMContentLoaded', function () {
-        Array.from(document.getElementsByClassName("button_team")).forEach(function(element) { 
-          element.addEventListener('click', function() {
-            createModalBox(element.id.slice(element.id.indexOf("_") + 1));
-          });
-        });
-      });
-  </script>
 </head>
 <body>
   <!-- Page Content -->


### PR DESCRIPTION
Fix #664. This is a continuation of the previous PR: https://github.com/nusskylab/nusskylab/pull/668

## Status
**READY**

## Migrations
NO

## Description
Change the position of the javascript function createModalBox to the head instead of at the bottom of the body.
(Update: After looking at the production server, I realised that chrome security policy does not allow inline javascript. So, I translate from removing inline javascript to put at the head)
(Update 2: As the bug still persist, I transferred the javascript code to a javascript file.)

Read this: https://developer.chrome.com/extensions/contentSecurityPolicy#JSExecution.

## Steps to Test or Reproduce
1. Select Projects at the navigation bar.
2. Click on any team button.
3. You should be able to see the modal box as below.
![screenshot 2019-03-01 at 21 44 01](https://user-images.githubusercontent.com/5901764/53642177-223bf500-3c6c-11e9-8ca3-eecb968c07b9.png)

