### PR TITLE
Cascade student deletion

### DIFF
--- a/app/models/student.rb
+++ b/app/models/student.rb
@@ -8,7 +8,7 @@ class Student < ActiveRecord::Base
   before_validation :fill_current_cohort
 
   belongs_to :user
-  belongs_to :team
+  belongs_to :team, dependent: :destroy
 
   def self.student?(user_id, extra = nil)
     if extra

--- a/spec/controllers/students_controller_spec.rb
+++ b/spec/controllers/students_controller_spec.rb
@@ -229,19 +229,25 @@ RSpec.describe StudentsController, type: :controller do
       end
 
       it 'should redirect with success for admin user for deletion of student with team' do
-        adviser1 = FactoryGirl.create(:adviser, user_id: subject.current_user.id)
+        adv_user = FactoryGirl.create(:user, email: '1@advisor.controller.spec', uid: '5.advisor.controller.spec')        
+        adviser1 = FactoryGirl.create(:adviser, user_id: adv_user.id)
         user1 = FactoryGirl.create(:user, email: '3@student.controller.spec', uid: '3.student.controller.spec')
         user2 = FactoryGirl.create(:user, email: '4@student.controller.spec', uid: '4.student.controller.spec')
-        team1 = FactoryGirl.create(:team, adviser: adviser1, team_name: '2.team.controller.spec')
+        team1 = FactoryGirl.create(:team, adviser: adviser1, team_name: '2.student.controller.spec')
         student1 = FactoryGirl.create(:student, user_id: user1.id, team: team1)
         student2 = FactoryGirl.create(:student, user_id: user2.id, team: team1)
         delete :destroy, id: student1.id
-        expect(response).to redirect_to(students_path(cohort: controller.current_cohort))
         
+        # expect successful deletion of team
+        expect(response).to redirect_to(students_path(cohort: controller.current_cohort))
+        expect(flash[:success]).not_to be_nil
+
         # expect the team record to be deleted
         expect{ team1.reload }.to raise_error ActiveRecord::RecordNotFound
-        # expect the other user to still exist
-        expect(Student.where(id: student2.id)).to exist
+        # check that student 1 is deleted
+        expect{ student1.reload }.to raise_error ActiveRecord::RecordNotFound
+        # check second student exists and has no team 
+        expect( student2.reload.team ).to be_nil
       end
 
     end

--- a/spec/controllers/students_controller_spec.rb
+++ b/spec/controllers/students_controller_spec.rb
@@ -218,7 +218,7 @@ RSpec.describe StudentsController, type: :controller do
       end
     end
 
-    context 'user logged in and admin' do
+    context 'user logged in and admin and user does not belong to team' do
       login_admin
       it 'should redirect with success for admin user' do
         user = FactoryGirl.create(:user, email: '2@student.controller.spec', uid: '2.student.controller.spec')
@@ -227,6 +227,23 @@ RSpec.describe StudentsController, type: :controller do
         expect(response).to redirect_to(students_path(cohort: controller.current_cohort))
         expect(flash[:success]).not_to be_nil
       end
+
+      it 'should redirect with success for admin user for deletion of student with team' do
+        adviser1 = FactoryGirl.create(:adviser, user_id: subject.current_user.id)
+        user1 = FactoryGirl.create(:user, email: '3@student.controller.spec', uid: '3.student.controller.spec')
+        user2 = FactoryGirl.create(:user, email: '4@student.controller.spec', uid: '4.student.controller.spec')
+        team1 = FactoryGirl.create(:team, adviser: adviser1, team_name: '2.team.controller.spec')
+        student1 = FactoryGirl.create(:student, user_id: user1.id, team: team1)
+        student2 = FactoryGirl.create(:student, user_id: user2.id, team: team1)
+        delete :destroy, id: student1.id
+        expect(response).to redirect_to(students_path(cohort: controller.current_cohort))
+        
+        # expect the team record to be deleted
+        expect{ team1.reload }.to raise_error ActiveRecord::RecordNotFound
+        # expect the other user to still exist
+        expect(Student.where(id: student2.id)).to exist
+      end
+
     end
   end
 end


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
This commit cascades student deletion to delete the team that the student is in. These are the example images:

![image](https://user-images.githubusercontent.com/17818981/57364646-35ac9480-71b6-11e9-8ff4-e3661c0920b5.png)

Deleting the second last user, name21 that belongs to team 1740, will cascade the deletion to the team without deleting his partner user, name1719:

![image](https://user-images.githubusercontent.com/17818981/57364793-70163180-71b6-11e9-992d-3720a9ccd749.png)

The team is also deleted from the team tab:

![image](https://user-images.githubusercontent.com/17818981/57364812-786e6c80-71b6-11e9-9d6a-c09e5b46ef9e.png)

I have also added tests for this functionality. My tests verify that 1. the team is deleted and 2. the second student still exists and have its team set to nil i.e. no team

## Related PRs
https://github.com/nusskylab/nusskylab/issues/679

## Todos
- [ ] Documentation  

## Deploy Notes
Nil.

## Steps to Test or Reproduce
Using the original fixtures, simply delete a student that belongs to a team (that does not have any outstanding peer evaluations).
