### PR TITLE
Reorganise Teams page

### DIFF
--- a/app/assets/javascripts/submissions.js
+++ b/app/assets/javascripts/submissions.js
@@ -77,6 +77,17 @@ $(function () {
   });
 });
 
+/**
+ * Link to submissions modal box
+ */
+function openModalBox(team_id) {
+  console.log("Open Modal Box");
+  var link = "modal_".concat(team_id);
+  if (window.location.hash === link) {
+    $(window.location.hash).modal();
+  }
+}
+
 function createModalBox(team_id) {
       var modal = document.getElementById("modal_".concat(team_id));
       var button = document.getElementById("button_".concat(team_id));

--- a/app/views/teams/_teams_table.html.erb
+++ b/app/views/teams/_teams_table.html.erb
@@ -1,7 +1,7 @@
 <table class="table table-hover table-sortable">
   <thead>
   <tr>
-    <th class="unsortable sort-index">Index</th><th>Team Name</th><th>Project Level</th><th>Has dropped</th>
+    <th class="unsortable sort-index">Index</th><th>Team Name</th><th>Project Level</th><th>Has dropped</th><th>Student 1</th><th>Student 2</th>
     <th>Adviser</th><th>Mentor</th><th>Submission 1</th><th>Submission 2</th><th>Submission 3</th><th class="unsortable">Cohort</th><th class="unsortable">Actions</th>
   </tr>
   </thead>
@@ -14,11 +14,40 @@
         </td>
         <td><%= team.get_project_level %></td>
         <td><%= team.has_dropped %></td>
+        <td><%= team.get_team_members[1] == nil ? "": team.get_team_members[0].user_name %></td>
+        <td><%= team.get_team_members[1] == nil ? "": team.get_team_members[1].user_name %></td>
         <td><%= team.adviser ? team.adviser.user.user_name : 'Not assigned' %></td>
         <td><%= team.mentor ? team.mentor.user.user_name : 'Not assigned' %></td>
-        <td><%= team.get_team_submission_status(team.get_own_submissions_in_order[1]) %></td>
-        <td><%= team.get_team_submission_status(team.get_own_submissions_in_order[2]) %></td>
-        <td><%= team.get_team_submission_status(team.get_own_submissions_in_order[3]) %></td>
+        <td>
+          <%if team.get_team_submission_status(team.get_own_submissions_in_order[1]) == "Submitted" %>
+          <!--<a class="btn btn-primary btn-xs" onClick="openModalBox(<%#= team.id %>)" href="../submissions/#modal_<%#=team.id %>"> Submission Link </a>-->
+            <a class="btn btn-primary btn-xs" href="<%#=team.get_own_submissions_in_order[1].video_link %>"> Video Link </a>
+            <br>
+            <a class="btn btn-primary btn-xs" href="<%#=team.get_own_submissions_in_order[1].poster_link %>"> Poster Link </a>
+          <% else %>
+            <%= team.get_team_submission_status(team.get_own_submissions_in_order[1]) %>
+          <% end %>
+        </td>
+        <td>
+          <%if team.get_team_submission_status(team.get_own_submissions_in_order[2]) == "Submitted" %>
+            <!--<a class="btn btn-primary btn-xs" onClick="openModalBox(<%#= team.id %>)" href="../submissions/#modal_<%#=team.id %>"> Submission Link </a>-->
+            <a class="btn btn-primary btn-xs" href="<%#=team.get_own_submissions_in_order[2].video_link %>"> Video Link </a>
+            <br>
+            <a class="btn btn-primary btn-xs" href="<%#=team.get_own_submissions_in_order[2].poster_link %>"> Poster Link </a>
+          <% else %>
+            <%= team.get_team_submission_status(team.get_own_submissions_in_order[3]) %>
+          <% end %>
+        </td>
+        <td>
+          <%if team.get_team_submission_status(team.get_own_submissions_in_order[3]) == "Submitted" %>
+            <!-- <a class="btn btn-primary btn-xs" onClick="openModalBox(<%= team.id %>)" href="../submissions/#modal_<%=team.id %>"> Submission Link </a> -->
+            <a class="btn btn-primary btn-xs" href="<%#=team.get_own_submissions_in_order[3].video_link %>"> Video Link </a>
+            <br>
+            <a class="btn btn-primary btn-xs" href="<%#=team.get_own_submissions_in_order[3].poster_link %>"> Poster Link </a>
+          <% else %>
+            <%= team.get_team_submission_status(team.get_own_submissions_in_order[3]) %>
+          <% end %>
+        </td>
         <td><%= team.cohort %></td>
         <td>
           <% if can_current_user_view_team(team) %>

--- a/app/views/teams/_teams_table.html.erb
+++ b/app/views/teams/_teams_table.html.erb
@@ -1,4 +1,4 @@
-<table class="table table-hover table-sortable">
+<table class="table table-hover table-sortable table-condensed">
   <thead>
   <tr>
     <th class="unsortable sort-index">Index</th><th>Team Name</th><th>Project Level</th><th>Has dropped</th><th>Student 1</th><th>Student 2</th>

--- a/app/views/teams/index.html.erb
+++ b/app/views/teams/index.html.erb
@@ -1,6 +1,6 @@
 <% content_for :main_content do %>
     <% javascript 'teams.js' %>
-    <div class="panel panel-info">
+    <div class="panel panel-info" style="width: min-content">
       <div class="panel-heading">
         <h3 class="text-center">Teams</h3>
       </div>


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
- Adds new columns 'Student 1' and 'Student 2' with team member names if the names are in the database, otherwise the values filled in the respective columns are empty strings
- Adds buttons for poster and video links respectively if the status of submission is 'Submitted'

## Related Issues
Issue #666 

Current Teams page: 
<img width="2554" alt="Screenshot 2019-05-09 at 1 16 41 PM" src="https://user-images.githubusercontent.com/30969577/57495703-f3906980-7301-11e9-8122-7c981a03b3ce.png">

Teams page after modifications in the PR:
<img width="2554" alt="Screenshot 2019-05-09 at 1 15 26 PM" src="https://user-images.githubusercontent.com/30969577/57495716-073bd000-7302-11e9-9400-3079d4c5ff37.png">


