### PR TITLE
Replace team image if not found

### DIFF
--- a/app/assets/javascripts/public_projects.js
+++ b/app/assets/javascripts/public_projects.js
@@ -20,6 +20,16 @@ function closeModal(modal) {
   modal.style.display = "none";
 }
 
+function replaceImg(image, team_level) {
+  if (team_level == 'vostok') {
+    return $(image).attr('src', "/assets/Vostok_Icon.jpg");
+  } else if (team_level == 'project_gemini') {
+    return $(image).attr('src', "/assets/Project_Gemini_Icon.png");
+  } else {
+    return $(image).attr('src', "/assets/Apollo_11_Icon.png");
+  }
+}
+
 document.addEventListener('DOMContentLoaded', function () {
   Array.from(document.getElementsByClassName("button_team")).forEach(function(element) { 
     element.addEventListener('click', function() {

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -287,24 +287,5 @@ class Team < ActiveRecord::Base
     evaluated_members
   end
 
-  def is_poster_valid
-    require "net/http"
-    begin
-      if !poster_link.blank? #Check if there's a poster link
-        url = URI.parse(poster_link) # parse link as a URI
-        req = Net::HTTP.new(url.host, url.port)
-        req.use_ssl = (url.scheme == 'https') # use ssl if https
-        res = req.request_head(url.path) # get request code
-        if res.code[0] == "4" or res.code[0] == "5" # http error status
-          return false 
-        else
-          return true
-        end
-      else
-        return false
-      end
-    rescue # exception raised when parsing html link
-      return false
-    end
-  end
 end
+

--- a/app/views/public_views/public_projects/_public_teams_table.html.erb
+++ b/app/views/public_views/public_projects/_public_teams_table.html.erb
@@ -34,8 +34,8 @@
   <div class="col-md-4 portfolio-item">
     <a role="button" onclick="createModalBox(<%= team.team_name %>)" id="button_<%= team.team_name %>">
       <% if !team.poster_link.blank? %>
-        <%= link_to image_tag(team.poster_link, size: "200", alt: "Team's Poster Link is not in image form",
-          title: "Click to view an enlarged version of this image."), team.poster_link %>
+        <%= link_to image_tag(team.poster_link, size: "200", alt: "Team's Poster Link is not in image form", 
+          title: "Click to view an enlarged version of this image.", id: "img_#{team.team_name}", onerror: "onerror=null;replaceImg(this, '#{team.project_level}')"), team.poster_link %>
       <% elsif locals[:selected_type] == 'Vostok' %>
         <%= image_tag("Vostok_Icon.jpg", size: "200", class: 'img-rounded inactive_link') %>
       <% elsif locals[:selected_type] == 'Project Gemini' %>

--- a/app/views/public_views/public_projects/_public_teams_table.html.erb
+++ b/app/views/public_views/public_projects/_public_teams_table.html.erb
@@ -33,7 +33,7 @@
   <% end %>
   <div class="col-md-4 portfolio-item">
     <a role="button" onclick="createModalBox(<%= team.team_name %>)" id="button_<%= team.team_name %>">
-      <% if team.is_poster_valid  %>
+      <% if !team.poster_link.blank? %>
         <%= link_to image_tag(team.poster_link, size: "200", alt: "Team's Poster Link is not in image form",
           title: "Click to view an enlarged version of this image."), team.poster_link %>
       <% elsif locals[:selected_type] == 'Vostok' %>


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
Resolves issue #656. On error of image tag, calls replaceImg(project_level) which replaces image of the team by the project level image. 

## Related PRs
Replace #658 as this PR used a inefficient method. 

## Todos
- [X] Add javascript to replace image.
- [X] Move script to public_views.js file


## Deploy Notes
NIL

## Image of result
Before:
![image](https://user-images.githubusercontent.com/35895537/57966929-10284380-798b-11e9-969f-10e94992a457.png)

After:
![image](https://user-images.githubusercontent.com/35895537/57966910-dce5b480-798a-11e9-937f-c0d81b9aa5b0.png)

* 
