### PR TITLE
Fix carousel if first image is not found

### DIFF
--- a/app/views/public_views/group_carousel/index.html.erb
+++ b/app/views/public_views/group_carousel/index.html.erb
@@ -5,22 +5,28 @@
   <div id="carousel" class="carousel slide" data-ride="carousel" data-interval="false">
     <!-- Indicators -->
     <ol class="carousel-indicators">
+      <% counter = 0 %>
       <% images.each_with_index do |image, index| %>
         <% if !image.blank? %>
-          <li data-target="#carousel" data-slide-to="<%= index %>" class="<%= index == 0 ? 'active' : '' %>"></li>
+          <li data-target="#carousel" data-slide-to="<%= index %>" class="<%= index - counter == 0 ? 'active' : '' %>"></li>
+        <% else %>
+          <% counter += 1 %>
         <% end %>
       <% end %>
     </ol>
     <!-- Wrapper for slides -->
     <div class="carousel-inner" role="listbox">
+      <% counter = 0 %>
       <% images.each_with_index do |image, index| %>
         <% if !image.blank? %>
-          <div class="item <%= index == 0 ? 'active' : '' %>">
+          <div class="item <%= index - counter == 0 ? 'active' : '' %>">
             <img src="<%= image %>" alt="<%= index %> Image">
             <div class="carousel-caption d-md-block">
               <h5 class="info"><%= @team_names[index]%></h5>
             </div>
           </div>
+        <% else %>
+          <% counter += 1 %>
         <% end %>
       <% end %>
     </div>


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
Previous ERB code adds class="active" into carousel element if image index is 0. If the image at index 0 is blank, this will not be done and the first element of carousel does not have the active class and carousel will not work. 
Added a counter to count for the number of images that is blank prior to the first non blank image and set class="active" at index-counter=0.  

## Related PRs
None

## Todos
- [X] Fixed carousel if first image in not uploaded


## Deploy Notes
None

## Steps to Test or Reproduce

## Fixes
Fixes #693 

* 
