### PR TITLE
Allow admin to view reg form

### DIFF
--- a/app/views/users/register_as_student.html.erb
+++ b/app/views/users/register_as_student.html.erb
@@ -5,7 +5,7 @@
         <h3 class="text-center">Register</h3>
       </div>
       <div class="panel-body">
-        <% if is_registration_open? %>
+        <% if is_registration_open? || current_user_admin? %>
           <p class="text-muted">You can further <a class="btn btn-info" href="<%= edit_user_path(@user.id) %>" target="_blank">complete</a> your profile for registration</p>
           <%= render 'registration_form', locals: {user: @user, survey_template: survey_template, registration: registration, questions: questions} %>
         <% else %>


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
Resolve #686 
Allow admin to view the submitted registration forms even when registration closes.

Before:
![Screenshot from 2019-05-27 21-53-24](https://user-images.githubusercontent.com/22557857/58424688-926ee100-80ca-11e9-94e9-f0a3561216d7.png)

After:
![Screenshot from 2019-05-27 21-56-02](https://user-images.githubusercontent.com/22557857/58424693-9569d180-80ca-11e9-8bdc-9b473208f441.png)
