### PR TITLE
Refactor permission fixes and fix #707

### DIFF
--- a/app/controllers/peer_evaluations_controller.rb
+++ b/app/controllers/peer_evaluations_controller.rb
@@ -118,15 +118,14 @@ class PeerEvaluationsController < ApplicationController
 
   def can_access_peer_evaluation(evaluators = false, evaluateds = false,
                                  advisees = false)
-    if params[:id]
-      team = PeerEvaluation.find(params[:id]).team
-      !authenticate_user(true, false,
-                         team.get_relevant_users(evaluators, evaluateds)) &&
-        (return false)
-    end
     if params[:team_id]
       team = Team.find(params[:team_id]) ||
              (raise ActiveRecord::RecordNotFound.new(t('application.record_not_found_message')))
+      if params[:id] # If accessing an existing peer evaluation
+        peer_eval = PeerEvaluation.find(params[:id]) ||
+                (raise ActiveRecord::RecordNotFound.new(t('application.record_not_found_message')))
+        team = peer_eval.team # To prevent unauthorized access through URL manipulation.
+      end
       !authenticate_user(true, false,
                         team.get_relevant_users(evaluators, evaluateds)) &&
        (return false)

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -63,18 +63,18 @@ class SubmissionsController < ApplicationController
   end
 
   def show
-    !authenticate_user(true, false, users_involved_in_evaluation) && return
     team = Team.find(params[:team_id]) || (record_not_found && return)
     @submission = Submission.find(params[:id]) || (record_not_found && return)
+    team = @submission.team # To prevent unauthorized access through URL manipulation.
     !authenticate_user(true, false,
                        team.get_relevant_users(true, false)) && return
     @page_title = t('.page_title')
   end
 
   def edit
-    !authenticate_user(true, false, users_involved_in_submission) && return
     team = Team.find(params[:team_id]) || (record_not_found && return)
     @submission = Submission.find(params[:id]) || (record_not_found && return)
+    team = @submission.team # To prevent unauthorized access through URL manipulation.
     !authenticate_user(true, false,
                        team.get_relevant_users(false, false)) && return
     @page_title = t('.page_title')
@@ -85,11 +85,11 @@ class SubmissionsController < ApplicationController
   end
 
   def update
-    !authenticate_user(true, false, users_involved_in_submission) && return
     team = Team.find(params[:team_id]) || (record_not_found && return)
     milestone = Milestone.find_by(id: params[:milestone_id]) ||
                 (record_not_found && return)
     @submission = Submission.find(params[:id]) || (record_not_found && return)
+    team = @submission.team # To prevent unauthorized access through URL manipulation.
     !authenticate_user(true, false,
                        team.get_relevant_users(false, false)) && return
     if update_submission
@@ -115,21 +115,6 @@ class SubmissionsController < ApplicationController
   end
 
   private
-
-  def users_involved_in_submission
-    Submission.find(params[:id]).team.students.map(&:user)
-  end
-
-  def users_involved_in_evaluation
-    submission_team = Submission.find(params[:id]).team
-
-    evaluatees = submission_team.students.map(&:user)
-    evaluating_rel = Evaluating.find_by(evaluated_id: submission_team.id)
-    evaluators = evaluating_rel ? Team.find(evaluating_rel.evaluator_id).students.map(&:user) : []
-    adviser = [submission_team.adviser.user]
-
-    evaluatees + evaluators + adviser
-  end
 
   def update_submission
     sub_params = submission_params


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
Refactor permission fixes and fix #707.
The main issue was that users are able to manipulate the URL such that they can "disguise" as team members from another team and view their submission/peer-evaluation. So the way it was fix was to check the permissions based on the submission/peer-evaluation's id. And from there, we obtain the authorized team and authorized set of users. Instead of just relying on the URL to determine the team.