### PR TITLE
Filter teams in dropdown box

### DIFF
--- a/app/controllers/evaluatings_controller.rb
+++ b/app/controllers/evaluatings_controller.rb
@@ -42,7 +42,7 @@ class EvaluatingsController < ApplicationController
     #   teams = adviser.teams.where(cohort: cohort)
     end
     @page_title = t('.page_title')
-    render locals: { teams: teams }
+    render locals: { teams: teams, adviser: adviser}
   end
 
   def create

--- a/app/views/evaluatings/_evaluating_form.html.erb
+++ b/app/views/evaluatings/_evaluating_form.html.erb
@@ -1,7 +1,14 @@
 <%= simple_form_for(locals[:evaluating], wrapper: :horizontal_form, html: {class: 'form-horizontal'},
                     url: {action: (locals[:is_new] ? 'create' : 'update')}) do |f| %>
     <%= f.error_notification %>
-    <%= f.input :evaluated_id, collection: locals[:teams].map {|team| [team.team_name, team.id]}, include_blank: false %>
-    <%= f.input :evaluator_id, collection: locals[:teams].map {|team| [team.team_name, team.id]}, include_blank: false %>
+    <% adviser = locals[:adviser] %>
+    <% user_is_adviser = !adviser.nil? %>
+    <% if user_is_adviser %>
+      <%= f.input :evaluated_id, collection: adviser.teams.map{|team| [team.team_name, team.id]}, include_blank: false %>
+      <%= f.input :evaluator_id, collection: adviser.teams.map{|team| [team.team_name, team.id]}, include_blank: false %>
+    <% else %>
+      <%= f.input :evaluated_id, collection: locals[:teams].map {|team| [team.team_name, team.id]}, include_blank: false %>
+      <%= f.input :evaluator_id, collection: locals[:teams].map {|team| [team.team_name, team.id]}, include_blank: false %>
+    <% end %>
     <%= f.button :submit_centred, class: 'btn-success' %>
 <% end %>

--- a/app/views/evaluatings/new.html.erb
+++ b/app/views/evaluatings/new.html.erb
@@ -5,7 +5,7 @@
         <h3 class="text-center">Create evaluation relationship</h3>
       </div>
       <div class="panel-body">
-        <%= render 'evaluating_form', locals: {evaluating: @evaluating, teams: teams, is_new: true} %>
+        <%= render 'evaluating_form', locals: {evaluating: @evaluating, teams: teams, is_new: true, adviser: adviser} %>
       </div>
     </div>
 <% end %>


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
Filters the teams in drop down box by advisor when creating new evaluating relationship. This will reduce the effort required to scroll down the whole list of teams. It's a simple fix for #702

## Steps to Test or Reproduce
1. Sign in to NUSSkylab as admin
2. Go to the [users page](https://nusskylab-dev.comp.nus.edu.sg/users) and preview as an adviser 
    (based on user name of an adviser in the [advisers page](https://nusskylab- 
     dev.comp.nus.edu.sg/advisers))
3. On the [home page](https://nusskylab-dev.comp.nus.edu.sg/users/xxx), select the user roles tab 
     and click on the 'An Adviser' button under the heading 'Use Skylab as: '
4. Go to the [Evaluatings page](https://nusskylab-dev.comp.nus.edu.sg/evaluatings) and click on the 
    'Create New Evaluation Relationship' button
5. Compare the teams in the drop down boxes with the respective team names listed under the 
     advisor in the [Teams page](https://nusskylab-dev.comp.nus.edu.sg/teams)