### PR TITLE
Remove the need to hardcode milestone number

### DIFF
--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -43,7 +43,7 @@ class SubmissionsController < ApplicationController
                 (record_not_found && return)
     !authenticate_user(true, false,
                        team.get_relevant_users(false, false)) && return
-    @submission = Submission.new(submission_params)
+    @submission = Submission.new(submission_params(milestone))
     if @submission.save
       redirect_to home_path, flash: {
         success: t('.success_message')
@@ -133,14 +133,20 @@ class SubmissionsController < ApplicationController
     @submission.errors[:video_link].any?
   end
 
-  def submission_params
+  def submission_params(milestone)
     submission_params = params.require(:submission).permit(:milestone_id,
                                                            :read_me,
                                                            :project_log,
                                                            :video_link,
-                                                           :poster_link)
+                                                           :poster_link,
+                                                           :milestone_number)
     submission_params[:team_id] = params[:team_id]
     submission_params[:milestone_id] = params[:milestone_id]
+    submission_params[:milestone_number] = get_milestone_number(milestone) 
     submission_params
+  end
+
+  def get_milestone_number(milestone)
+    milestone.name[-1].to_i
   end
 end

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -120,6 +120,7 @@ class SubmissionsController < ApplicationController
     sub_params = submission_params
     sub_params[:milestone_id] = @submission.milestone_id
     sub_params[:team_id] = @submission.team_id
+    sub_params[:milestone_number] = get_milestone_number(milestone) 
     @submission.update(sub_params) ? @submission : nil
   end
 

--- a/app/controllers/submissions_controller.rb
+++ b/app/controllers/submissions_controller.rb
@@ -92,7 +92,7 @@ class SubmissionsController < ApplicationController
     team = @submission.team # To prevent unauthorized access through URL manipulation.
     !authenticate_user(true, false,
                        team.get_relevant_users(false, false)) && return
-    if update_submission
+    if update_submission(milestone)
       redirect_to home_path, flash: {
         success: t('.success_message')
       }
@@ -116,11 +116,10 @@ class SubmissionsController < ApplicationController
 
   private
 
-  def update_submission
-    sub_params = submission_params
+  def update_submission(milestone)
+    sub_params = submission_params(milestone)
     sub_params[:milestone_id] = @submission.milestone_id
     sub_params[:team_id] = @submission.team_id
-    sub_params[:milestone_number] = get_milestone_number(milestone) 
     @submission.update(sub_params) ? @submission : nil
   end
 

--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -143,7 +143,13 @@ class Team < ActiveRecord::Base
   def get_own_submissions_in_order
     submissions_hash = {}
     submissions.each do |submission|
-      milestone_number = get_milestone_number_from_milestone_id(submission.milestone_id)
+      milestone_number = submission.milestone_number
+      
+      # for older cohorts, i.e. milestone_number = 0, will use back old formula to calculate milestone_number from milestone_id
+      if milestone_number == 0
+        milestone_number = get_milestone_number_from_milestone_id(submission.milestone_id)
+      end
+
       submissions_hash[milestone_number] = submission
     end
     submissions_hash

--- a/app/views/milestones/_milestone_form.html.erb
+++ b/app/views/milestones/_milestone_form.html.erb
@@ -1,7 +1,7 @@
 <%= simple_form_for(locals[:milestone], wrapper: :horizontal_form, html: {class: 'form-horizontal'},
                     url: {action: (locals[:is_new] ? 'create' : 'update')}) do |f| %>
     <%= f.error_notification %>
-    <%= f.input :name, input_html: {placeholder: 'input milestone name'}, required: true %>
+    <%= f.input :name, :collection => %w[Milestone\ 1 Milestone\ 2 Milestone\ 3], include_blank: false, required: true %>
     <%= f.input :submission_deadline, as: :string, input_html: { value: (l(f.object.submission_deadline) if f.object.submission_deadline), class: 'datetime-picker' } %>
     <%= f.input :peer_evaluation_deadline, as: :string, input_html: { value: (l(f.object.peer_evaluation_deadline) if f.object.peer_evaluation_deadline), class: 'datetime-picker' } %>
     <%= f.button :submit_centred, class: 'btn-success' %>

--- a/app/views/teams/_teams_table.html.erb
+++ b/app/views/teams/_teams_table.html.erb
@@ -31,7 +31,7 @@
             <% submission = team.get_own_submissions_in_order[2] %>
             <a class="btn btn-primary btn-s" href="<%= milestone_team_submission_path(submission.milestone_id, submission.team_id, submission.id)%>"> View Submission </a>
           <% else %>
-            <%= team.get_team_submission_status(team.get_own_submissions_in_order[3]) %>
+            <%= team.get_team_submission_status(team.get_own_submissions_in_order[2]) %>
           <% end %>
         </td>
         <td>

--- a/db/migrate/20190601175910_add_milestone_number_to_submissions.rb
+++ b/db/migrate/20190601175910_add_milestone_number_to_submissions.rb
@@ -1,0 +1,5 @@
+class AddMilestoneNumberToSubmissions < ActiveRecord::Migration
+  def change
+    add_column :submissions, :milestone_number, :integer, null:false, default:0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -11,7 +11,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20190506181849) do
+ActiveRecord::Schema.define(version: 20190601175910) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -165,16 +165,17 @@ ActiveRecord::Schema.define(version: 20190506181849) do
   add_index "students", ["user_id"], name: "index_students_on_user_id", using: :btree
 
   create_table "submissions", force: :cascade do |t|
-    t.integer  "milestone_id",                 null: false
-    t.integer  "team_id",                      null: false
-    t.boolean  "published",    default: false
-    t.datetime "created_at",                   null: false
-    t.datetime "updated_at",                   null: false
+    t.integer  "milestone_id",                     null: false
+    t.integer  "team_id",                          null: false
+    t.boolean  "published",        default: false
+    t.datetime "created_at",                       null: false
+    t.datetime "updated_at",                       null: false
     t.string   "video_link"
     t.text     "read_me"
     t.text     "project_log"
-    t.boolean  "show_public",  default: true
+    t.boolean  "show_public",      default: true
     t.string   "poster_link"
+    t.integer  "milestone_number", default: 0,     null: false 
   end
 
   add_index "submissions", ["milestone_id"], name: "index_submissions_on_milestone_id", using: :btree


### PR DESCRIPTION
## Status
**READY**

## Migrations
YES 

## Description
- Changed milestone creation such that the name can only be milestone 1, milestone 2 or milestone 3.
- Add a new column to submissions (milestone_number). This milestone number will determine which milestone is this submission for. Milestone number is derived from the name of the milestone.
- In team.rb, removed hard coding for get_milestone_number_from_milestone_id.

## Related PRs
NIL

## Todos
- [ ] Tests


## Deploy Notes
Steps to do to reset database:
bundle exec rake db:reset
bundle exec rake db:fixtures:load RAILS_ENV="development"
and reinsert yourself into db as admin

## Steps to Test or Reproduce
NIL

## Fixes
Fixes #696 
* 
