### PR TITLE
Display peer evaluations of each team in adviser home page

### DIFF
--- a/app/views/advisers/_adviser_teams.html.erb
+++ b/app/views/advisers/_adviser_teams.html.erb
@@ -4,7 +4,9 @@
     <tr>
       <th>Team Name</th>
       <th>Level of achievement</th>
-      <th>Evaluated teams</th>
+      <% locals[:milestones].each do |milestone| %>
+      <th><%= milestone.name %> evaluations </th>
+      <% end %>
       <th>Action</th>
     </tr>
     </thead>
@@ -17,11 +19,23 @@
           <td>
             <%= team.get_project_level %>
           </td>
+          <%locals[:milestones].each do |milestone| %>
           <td>
             <% team.evaluateds.each do |evaluated| %>
-                <%= evaluated.evaluated.team_name %><br>
-            <% end %>
+                <% peer_evaluation_id = nil %>
+                <% for peer_evaluation in team.peer_evaluations do %>
+                    <%  if peer_evaluation.submission.team_id == evaluated.evaluated_id %>
+                        <% peer_evaluation_id = peer_evaluation.id%>
+                    <% end %>
+                <% end %>
+                <% if peer_evaluation_id != nil %>
+                    <a href="<%= milestone_team_peer_evaluation_path(milestone.id, evaluated.evaluator_id, peer_evaluation_id) %>" class="btn btn-info"><%= evaluated.evaluated.team_name %></a> <br> <br>
+                <% else %>
+                    <a class="btn btn-default" disabled="disabled"><%= evaluated.evaluated.team_name %></a> <br><br>
+                 <% end %>
+             <% end %>
           </td>
+          <% end %>
           <td>
             <a href="<%= edit_team_path(team) %>" class="btn btn-success">Edit</a>
           </td>

--- a/app/views/advisers/show.html.erb
+++ b/app/views/advisers/show.html.erb
@@ -34,7 +34,7 @@
             <div class="well">
               <p class="small"><%= t '.view_teams_instruction' %></p>
             </div>
-            <%= render 'adviser_teams', locals: {adviser: @role} %>
+            <%= render 'adviser_teams', locals: { adviser: @role, milestones: role_data[:milestones]} %>
           </div>
           <div role="tabpanel" class="tab-pane fade" id="evaluations-panel">
             <h2 class="text-center">Evaluations</h2>


### PR DESCRIPTION
Signed-off-by: Aadit <aadit.k12@gmail.com>

## Status
**READY**

## Migrations
NO

## Description
Replaces the **Evaluated teams** column of the table on the **View all your teams** tab of the adviser home page with multiple columns, one for each milestone. In each column, there is a button for each team evaluated linking to the peer evaluation for that milestone (if there is no peer evaluation for the team, then the button is grayed out).

Before:
<img width="2702" alt="before" src="https://user-images.githubusercontent.com/30969577/59976971-18b11100-95fe-11e9-817c-f6c20c9e5614.png">


After: 
<img width="2532" alt="after" src="https://user-images.githubusercontent.com/30969577/59976975-367e7600-95fe-11e9-8e0e-364b7567bce7.png">


## Fixes
Resolves #720
