### PR TITLE
add db cleaner to reset db state between tests

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -46,6 +46,20 @@ RSpec.configure do |config|
     mocks.verify_partial_doubles = true
   end
 
+  # clean the FactoryGirl Database between each run
+  config.before(:suite) do
+    DatabaseCleaner.strategy = :transaction
+    DatabaseCleaner.clean_with(:truncation)
+  end
+
+  config.before(:each) do
+    DatabaseCleaner.start
+  end
+
+  config.after(:each) do
+    DatabaseCleaner.clean
+  end
+
 # The settings below are suggested to provide a good initial experience
 # with RSpec, but feel free to customize to your heart's content.
 =begin


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
Reset the FactoryGirl Database state between each run. From the image below, I printed out the created team ids. We see that for each run, the created ids are dependent on the test run, this might create some issues in the future, since it is unintended
![image](https://user-images.githubusercontent.com/17818981/60083117-aceab780-9767-11e9-818f-bec72cfbe982.png)

After fixing, we see that the created team ids are the same across test runs. 
![image](https://user-images.githubusercontent.com/17818981/60083186-d1469400-9767-11e9-85a5-d7a5a70cb951.png)

I think this is a necessary fix because there might be some carryover states from previous runs. This means that the state of each test can possibly be different, and allow some bugs to slip through. 

## Related PRs
-

## Steps to Test or Reproduce
Comment out the added code and print out the team ids of any one of the teams created in teams_rspec.db. Then add the code back in then test again. 

## Fixes

* 
