### PR TITLE
Fix error in peer submissions link on the advisor home page

### DIFF
--- a/app/views/advisers/_adviser_teams.html.erb
+++ b/app/views/advisers/_adviser_teams.html.erb
@@ -5,42 +5,44 @@
       <th>Team Name</th>
       <th>Level of achievement</th>
       <% locals[:milestones].each do |milestone| %>
-      <th><%= milestone.name %> evaluations </th>
+        <th><%= milestone.name %> evaluations</th>
       <% end %>
       <th>Action</th>
     </tr>
     </thead>
     <tbody>
-      <% locals[:adviser].teams.each do |team| %>
-        <tr>
-          <td>
-            <a href="<%= team_path(team) %>" class="btn btn-info"><%= team.team_name %></a>
-          </td>
-          <td>
-            <%= team.get_project_level %>
-          </td>
-          <%locals[:milestones].each do |milestone| %>
+    <% locals[:adviser].teams.each do |team| %>
+      <tr>
+        <td>
+          <a href="<%= team_path(team) %>" class="btn btn-info"><%= team.team_name %></a>
+        </td>
+        <td>
+          <%= team.get_project_level %>
+        </td>
+        <% locals[:milestones].each do |milestone| %>
           <td>
             <% team.evaluateds.each do |evaluated| %>
-                <% peer_evaluation_id = nil %>
-                <% for peer_evaluation in team.peer_evaluations do %>
-                    <%  if peer_evaluation.submission.team_id == evaluated.evaluated_id %>
-                        <% peer_evaluation_id = peer_evaluation.id%>
-                    <% end %>
+              <% peer_evaluation_id = nil %>
+              <% for peer_evaluation in team.peer_evaluations do %>
+                <% submission = peer_evaluation.submission %>
+                <% if submission.team_id == evaluated.evaluated_id and submission.milestone_id == milestone.id %>
+                  <% peer_evaluation_id = peer_evaluation.id %>
                 <% end %>
-                <% if peer_evaluation_id != nil %>
-                    <a href="<%= milestone_team_peer_evaluation_path(milestone.id, evaluated.evaluator_id, peer_evaluation_id) %>" class="btn btn-info"><%= evaluated.evaluated.team_name %></a> <br> <br>
-                <% else %>
-                    <a class="btn btn-default" disabled="disabled"><%= evaluated.evaluated.team_name %></a> <br><br>
-                 <% end %>
-             <% end %>
+              <% end %>
+              <% if peer_evaluation_id != nil %>
+                <a href="<%= milestone_team_peer_evaluation_path(milestone.id, evaluated.evaluator_id, peer_evaluation_id) %>" class="btn btn-info"><%= evaluated.evaluated.team_name %></a>
+                <br> <br>
+              <% else %>
+                <a class="btn btn-default" disabled="disabled"><%= evaluated.evaluated.team_name %></a> <br><br>
+              <% end %>
+            <% end %>
           </td>
-          <% end %>
-          <td>
-            <a href="<%= edit_team_path(team) %>" class="btn btn-success">Edit</a>
-          </td>
-        </tr>
-      <% end %>
+        <% end %>
+        <td>
+          <a href="<%= edit_team_path(team) %>" class="btn btn-success">Edit</a>
+        </td>
+      </tr>
+    <% end %>
     </tbody>
   </table>
 </div>


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
There was a [missing milestone id check](https://github.com/nusskylab/nusskylab/pull/727/files#r298233410) that led to the Milestone 1 peer submission being shown in all the 3 columns for each team. Attached are the screenshots for one of the advisers in my mock data, before and after the change:

<h3>Before the change: </h3>

<img width="2548" alt="Screenshot 2019-06-27 at 11 07 38 PM" src="https://user-images.githubusercontent.com/30969577/60277786-d99dfb00-9930-11e9-94b3-d40aa53b921f.png">


<h3>After the change:</h3>

<img width="2548" alt="Screenshot 2019-06-27 at 11 06 46 PM" src="https://user-images.githubusercontent.com/30969577/60277794-ddca1880-9930-11e9-8c80-affeac21508d.png">

In this set of test data, I have created peer evaluations for Milestone 1, 2 and 3 submissions of team `I am Team 1733` and for Milestone 1 submissions of teams `1717` and `I am team 1736`. Earlier, the uncreated peer evaluations were not grayed out but now those that have not been created are grayed out and the buttons link to the submissions of the respective team for the correct milestone.

The other lines of code changes are changes in code formatting for the file in question.

## Fixes
Fixes #720
