### PR TITLE
Fix unnatural spacing in gallery and update page titles

### DIFF
--- a/app/views/submissions/_submissions_display.html.erb
+++ b/app/views/submissions/_submissions_display.html.erb
@@ -3,64 +3,73 @@
     <div class="col-lg-12">
       <h1 class="page-header"><%= project_level_header(project_level_text(locals[:selected_type]), locals[:teams].length) %></h1>
     </div>
-    <% locals[:teams].each_with_index do |team, idx| %>
+  </div>
+  <% teams, max_no_of_columns = locals[:teams], 4 %>
+  <% for i in (0..teams.length - 1).step(max_no_of_columns) do %>
+    <div class="row">
       <!-- Thumbnail display for each team -->
-      <div class="col-lg-3 col-md-4 col-xs-6 thumb">
-        <%= link_to image_tag(image_tag_string(locals[:selected_type]), class: 'img-rounded') %>
-        <h3>
-          <button type="button" class="btn button_team btn-lg" id="button_<%= idx %>" data-toggle="modal" data-target="#modal_<%= team.id %>">
-            <%= idx + 1 %>. <%= team.team_name %>
-          </button>
-        </h3>
-        <p class="text-muted">Students: <%= team.students.map {|student| student.user.user_name}.join(' & ') %></p>
-        <p class="text-muted">Advised by: <%= team.adviser ? team.adviser.user.user_name : 'Not assigned' %></p>
-      </div>
-      <!-- End of thumbnail display -->
+      <% for idx in (i ..i + max_no_of_columns - 1) do %>
+        <% team = teams[idx] %>
+        <% if team == nil %>
+          <% break %>
+        <% end %>
+        <div class="col-lg-3 col-md-4 col-xs-6 thumb">
+          <%= link_to image_tag(image_tag_string(locals[:selected_type]), class: 'img-rounded') %>
+          <h3>
+            <button type="button" class="btn button_team btn-lg" id="button_<%= idx %>" data-toggle="modal" data-target="#modal_<%= team.id %>">
+              <%= idx + 1 %>. <%= team.team_name %>
+            </button>
+          </h3>
+          <p class="text-muted">Students: <%= team.students.map { |student| student.user.user_name }.join(' & ') %></p>
+          <p class="text-muted">Advised by: <%= team.adviser ? team.adviser.user.user_name : 'Not assigned' %></p>
+        </div>
+        <!-- End of thumbnail display -->
 
-      <!-- Modal box: Display all the team's submissions -->
-      <div id="modal_<%= team.id %>" class="modal fade" role="dialog">
-        <div class="modal-dialog modal-lg">
-          <!-- Modal content-->
-          <div class="modal-content">
-            <div class="modal-header">
-              <button type="button" class="close" data-dismiss="modal">&times;</button>
-              <h4 class="modal-title"><%= team.team_name %>'s submissions</h4>
-            </div>
-            <div class="modal-body">
+        <!-- Modal box: Display all the team's submissions -->
+        <div id="modal_<%= team.id %>" class="modal fade" role="dialog">
+          <div class="modal-dialog modal-lg">
+            <!-- Modal content-->
+            <div class="modal-content">
+              <div class="modal-header">
+                <button type="button" class="close" data-dismiss="modal">&times;</button>
+                <h4 class="modal-title"><%= team.team_name %>'s submissions</h4>
+              </div>
+              <div class="modal-body">
 
-              <!-- Tab Content -->
-              <% team_submission = Submission.where(team_id: team.id); %>
-              <% if (team_submission.length > 0) %>
-                <ul class="nav nav-tabs">
-                  <% team_submission.order(:milestone_id).each do |submission| %>
-                    <li>
-                      <a data-toggle="tab" href="#team_<%= submission.team_id %>_milestone_<%= submission.milestone_id %>">Milestone <%= submission.milestone_id %></a>
-                    </li>
-                  <% end %>
-                </ul>
-                <div class="tab-content">
-                  <% team_submission.order(:milestone_id).each do |submission| %>
-                    <div id="team_<%= submission.team_id %>_milestone_<%= submission.milestone_id %>" class="tab-pane fade in">
-                      <!--                      Team <%#= submission.team_id %>-->
-                      <!--                      Milestone <%#= submission.milestone_id %>-->
-                      <%= render 'submission_details', locals: {submission: submission} %>
-                    </div>
-                  <% end %>
-                </div>
-              <% else %>
-                <h3>No submissions submitted</h3>
-              <% end %>
-              <!-- End of Tab Content -->
+                <!-- Tab Content -->
+                <% team_submission = Submission.where(team_id: team.id); %>
+                <% if (team_submission.length > 0) %>
+                  <ul class="nav nav-tabs">
+                    <% team_submission.order(:milestone_id).each do |submission| %>
+                      <li>
+                        <a data-toggle="tab" href="#team_<%= submission.team_id %>_milestone_<%= submission.milestone_id %>">Milestone <%= submission.milestone_id %></a>
+                      </li>
+                    <% end %>
+                  </ul>
+                  <div class="tab-content">
+                    <% team_submission.order(:milestone_id).each do |submission| %>
+                      <div id="team_<%= submission.team_id %>_milestone_<%= submission.milestone_id %>" class="tab-pane fade in">
+                        <!--                      Team <%#= submission.team_id %>-->
+                        <!--                      Milestone <%#= submission.milestone_id %>-->
+                        <%= render 'submission_details', locals: {submission: submission} %>
+                      </div>
+                    <% end %>
+                  </div>
+                <% else %>
+                  <h3>No submissions submitted</h3>
+                <% end %>
+                <!-- End of Tab Content -->
 
-            </div>
-            <div class="modal-footer">
-              <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+              </div>
+              <div class="modal-footer">
+                <button type="button" class="btn btn-default" data-dismiss="modal">Close</button>
+              </div>
             </div>
           </div>
         </div>
-      </div>
-      <!-- End of modal box -->
-    <% end %>
-  </div>
+        <!-- End of modal box -->
+      <% end %>
+    </div>
+  <% end %>
 </div>
 


### PR DESCRIPTION
## Status
**IN DEVELOPMENT**

## Migrations
YES

## Description
I followed [this suggestion](https://stackoverflow.com/questions/22866109/bootstrap-columns-not-aligning-correctly) and put the projects in each row within the Gallery into its own `<div class=“row”>` tag, instead of combining all of them under one tag. In order to do this, I had to modify the [outer for loop to run in steps of `max_no_of_columns`](https://github.com/nusskylab/nusskylab/blob/d997683b717edbf13ccc83609806ec1790f2e79f/app/views/submissions/_submissions_display.html.erb#L8) and then [create another inner for loop to render each project in the row](https://github.com/nusskylab/nusskylab/blob/d997683b717edbf13ccc83609806ec1790f2e79f/app/views/submissions/_submissions_display.html.erb#L11). The `max_no_of_columns` variable is hardcoded with the value 4, because the maximum number of columns that can be accomodated in the Bootstrap grid is 4 as [per the setting for large devices](https://github.com/nusskylab/nusskylab/pull/731/files#r298819934). This hardcoding sometimes causes issues when viewport width is changed (as shown in the screenshot for Medium devices **after** the changes

I was earlier thinking of using JavaScript to determine the size of the viewport and then assigning the variable `no_of_columns` with a value depending on the viewport size to run the for loop in steps of `no_of_columns`, but I could not find a good way of accessing JavaScript variables within the embedded HTML ruby files.

Additionally, I also changed the [config file]( so that the 

## Screenshots

### Before:

- #### Extra small devices (phones, less than 768px) and Small devices (tablets, 768px and up):
<img width="500" alt="Screenshot 2019-06-30 at 2 10 19 PM" src="https://user-images.githubusercontent.com/30969577/60393167-91a2f200-9b43-11e9-8a71-b4ca34caa8a9.png">





- #### Medium devices (desktops, 992px and up):
<img width="1012" alt="Screenshot 2019-06-30 at 2 10 00 PM" src="https://user-images.githubusercontent.com/30969577/60393182-bbf4af80-9b43-11e9-949e-040397c00dc4.png">



- #### Large devices (large desktops, 1200px and up):
<img width="1286" alt="Screenshot 2019-06-30 at 2 09 35 PM" src="https://user-images.githubusercontent.com/30969577/60393184-c7e07180-9b43-11e9-9979-934877e23878.png">


### After:

- #### Extra small devices (phones, less than 768px) and Small devices (tablets, 768px and up):

<img width="898" alt="Screenshot 2019-06-30 at 2 11 19 PM" src="https://user-images.githubusercontent.com/30969577/60393100-87ccbf00-9b42-11e9-90fe-dfbbb13fb0c7.png">


- #### Medium devices (desktops, 992px and up):

<img width="1079" alt="Screenshot 2019-06-30 at 2 13 03 PM" src="https://user-images.githubusercontent.com/30969577/60393108-974c0800-9b42-11e9-98eb-bd0ce472919f.png">


- #### Large devices (large desktops, 1200px and up):
<img width="1788" alt="Screenshot 2019-06-30 at 1 56 22 PM" src="https://user-images.githubusercontent.com/30969577/60393110-9a46f880-9b42-11e9-9759-2fa26566ca5b.png">

Note: The size are based on the [Bootstrap grid layout](https://getbootstrap.com/docs/3.3/css/#grid)

## Fixes
- Fixes #726 
- Fixes #732