### PR TITLE
Corrected milestone number in all teams page

### DIFF
--- a/app/models/submission.rb
+++ b/app/models/submission.rb
@@ -13,4 +13,12 @@ class Submission < ActiveRecord::Base
   def submitted_late?
     updated_at > milestone.submission_deadline
   end
+
+  def get_milestone_number
+    if milestone_number == 0
+      (milestone_id - 1) % 3 + 1
+    else
+      milestone_number
+    end
+  end
 end

--- a/app/views/submissions/_submissions_display.html.erb
+++ b/app/views/submissions/_submissions_display.html.erb
@@ -34,7 +34,7 @@
                 <ul class="nav nav-tabs">
                   <% team_submission.order(:milestone_id).each do |submission| %>
                     <li>
-                      <a data-toggle="tab" href="#team_<%= submission.team_id %>_milestone_<%= submission.milestone_id %>">Milestone <%= submission.milestone_id %></a>
+                      <a data-toggle="tab" href="#team_<%= submission.team_id %>_milestone_<%= submission.milestone_id %>">Milestone <%= submission.get_milestone_number %></a>
                     </li>
                   <% end %>
                 </ul>


### PR DESCRIPTION
added function to get milestone number from milestone_number attribute in Submissions model

## Status
**READY**

## Migrations
NO

## Description
Milestone number was retrieved from milestone id, which is default incremental from the db. Added a function to get the number from the milestone_number attribute in Submissions table introduced in PR #696 

## Related PRs
PR #696 

## Deploy Notes
NIL

## Steps to Test or Reproduce
Go to All Teams page, click on team's name

## Fixes
Closes #730 

* 
