### PR TITLE
Add dropdown for Project level field when creating a new team

### DIFF
--- a/app/controllers/teams_controller.rb
+++ b/app/controllers/teams_controller.rb
@@ -102,7 +102,7 @@ class TeamsController < ApplicationController
   def team_params
     team_ps = params.require(:team).permit(:team_name, :project_level,
                                            :adviser_id, :mentor_id,
-                                           :has_dropped, :cohort, :poster_link, 
+                                           :has_dropped, :cohort, :poster_link,
                                            :video_link, :status, :comment)
     team_ps[:project_level] = Team.get_project_level_from_raw(
       team_ps[:project_level]) if team_ps[:project_level]

--- a/app/views/teams/_team_form.html.erb
+++ b/app/views/teams/_team_form.html.erb
@@ -2,20 +2,11 @@
                     url: {action: (locals[:is_new] ? 'create' : 'update')}) do |f| %>
   <%= f.error_notification %>
   <%= f.input :team_name %>
-  <% if is_project_level_locked? %>
-    <div class="form-group string required team_team_name">
-      <label class="string required col-sm-3 control-label"> Project level </label>
-      <div class="col-sm-9">
-        <p class="string required form-control"><%= locals[:team].get_project_level %></p>
-      </div>
-    </div>
-  <% else %>
-    <%= f.input :project_level, collection: {Vostok: 'Vostok',
-                                            'Project Gemini'.to_sym => 'Project Gemini',
-                                            'Apollo 11'.to_sym => 'Apollo 11'},
+  <%= f.input :project_level, collection: {Vostok: 'Vostok',
+                                           'Project Gemini'.to_sym => 'Project Gemini',
+                                           'Apollo 11'.to_sym => 'Apollo 11'},
                                 selected: locals[:team].get_project_level,
                                 include_blank: false, required: true %>
-  <% end %>
   <% if current_user_admin? %>
     <%= f.input :adviser_id, collection: locals[:advisers].map {|adviser| [adviser.user.user_name, adviser.id]}, include_blank: 'Not assigned', required: true %>
     <%= f.input :mentor_id, collection: locals[:mentors].map {|mentor| [mentor.user.user_name, mentor.id]}, include_blank: 'Not assigned' %>


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
Not sure why there was an if else condition for locking the project level when creating a new team. I've removed this condition so that while creating new team the appropriate project level can be assigned.

## Screenshots

#### Before:

<img width="1139" alt="Screenshot 2019-07-21 at 12 07 32 PM" src="https://user-images.githubusercontent.com/30969577/61586926-a78b5c00-abb1-11e9-8b55-27292a0089f5.png">


#### After:

<img width="1139" alt="Screenshot 2019-07-21 at 12 23 47 PM" src="https://user-images.githubusercontent.com/30969577/61586958-72333e00-abb2-11e9-89b5-2044db2e9d74.png">


## Fixes
Fixes #752