### PR TITLE
Lazy load projects

### DIFF
--- a/app/controllers/public_views/public_projects_controller.rb
+++ b/app/controllers/public_views/public_projects_controller.rb
@@ -4,11 +4,25 @@ class PublicViews::PublicProjectsController < ApplicationController
     !authenticate_user(false, false) && return
     @page_title = t('.page_title')
     @teams_table = {}
-    all_cohorts.each do |cohort|
+    @cohorts = all_cohorts
+    [all_cohorts.first].each do |cohort|
       teams = Team.where(
         cohort: cohort, has_dropped: false
       ).order(:project_level).reverse_order
       @teams_table[cohort] = teams
     end
+  end
+
+  def show
+    !authenticate_user(false, false) && return
+    @cohort = params[:id]
+    @teams = Team.where(
+      cohort: @cohort, has_dropped: false
+    ).order(:project_level).reverse_order
+
+    render 'show.js.erb', locals: {
+      cohort: @cohort,
+      teams: @teams
+    }
   end
 end

--- a/app/views/public_views/public_projects/_public_cohort_projects.html.erb
+++ b/app/views/public_views/public_projects/_public_cohort_projects.html.erb
@@ -1,0 +1,34 @@
+<ul class="nav nav-pills">
+  <li class="active"><a data-toggle="pill" href="#vostok<%=locals[:cohort]%>">Vostok</a></li>
+  <li><a data-toggle="pill" href="#project_gemini<%=locals[:cohort]%>">Project Gemini</a></li>
+  <li><a data-toggle="pill" href="#apollo_11<%=locals[:cohort]%>">Apollo 11</a></li>
+</ul>
+<div class="tab-content">
+  <div id="vostok<%=locals[:cohort]%>" class="tab-pane fade in active">
+    <% if locals[:teams].select{|team| team.vostok?}.length > 0 %>
+      <%= render 'public_teams_table', locals: {teams: locals[:teams],
+        selected_teams: locals[:teams].select{|team| team.vostok?},
+        selected_type: 'Vostok'} %>
+    <% else %>
+      No Data Available
+    <% end %>
+  </div>
+  <div id="project_gemini<%=locals[:cohort]%>" class="tab-pane fade">
+    <% if locals[:teams].select{|team| team.project_gemini?}.length > 0 %>
+      <%= render 'public_teams_table', locals: {teams: locals[:teams],
+        selected_teams: locals[:teams].select{|team| team.project_gemini?},
+        selected_type: 'Project Gemini'} %>
+    <% else %>
+      No Data Available
+    <% end %>
+  </div>
+  <div id="apollo_11<%=locals[:cohort]%>" class="tab-pane fade">
+    <% if locals[:teams].select{|team| team.apollo_11?}.length > 0 %>
+      <%= render 'public_teams_table', locals: {teams: locals[:teams],
+        selected_teams: locals[:teams].select{|team| team.apollo_11?},
+        selected_type: 'Apollo 11'} %>
+    <% else %>
+      No Data Available
+    <% end %>
+  </div>
+</div>

--- a/app/views/public_views/public_projects/index.html.erb
+++ b/app/views/public_views/public_projects/index.html.erb
@@ -1,52 +1,23 @@
 <% javascript 'public_projects.js' %>
 <% first_loop = true; %>
 <ul class="nav nav-pills nav-stacked col-md-2" id="all_cohorts">
-	<% @teams_table.each do | cohort, teams | %>
-	<li>
-		<a role="button" data-toggle="pill" href="#<%=cohort%>" class="<% if first_loop %>active<% first_loop = false; end %>">
+	<% @cohorts.each do | cohort | %>
+  <% if first_loop %> <% active="active"; first_loop = false; end %>
+	<li class='tab-button <%=active%>'>
+    <%= link_to "Cohort #{cohort}", public_views_public_project_path(cohort),
+      id: "toggle-#{cohort}", remote: true, role: 'button'%>
+		<a id="rendered-toggle-<%=cohort%>", role="button" data-toggle="pill"
+      href="#<%=cohort%>" style="display: none">
 			Cohort <%= cohort %>
 		</a>
 	</li>
 	<% end %>
 </ul>
 <% first_loop = true; %>
-<div class="tab-content col-md-10">
+<div class="tab-content col-md-10" id="project-display">
 	<% @teams_table.each do | cohort, teams | %>
 	<div class="tab-pane fade <% if first_loop %>in active<% first_loop = false; end %>" id="<%=cohort%>">
-		<ul class="nav nav-pills">
-			<li class="active"><a data-toggle="pill" href="#vostok<%=cohort%>">Vostok</a></li>
-			<li><a data-toggle="pill" href="#project_gemini<%=cohort%>">Project Gemini</a></li>
-			<li><a data-toggle="pill" href="#apollo_11<%=cohort%>">Apollo 11</a></li>
-		</ul>
-		<div class="tab-content">
-			<div id="vostok<%=cohort%>" class="tab-pane fade in active">
-				<% if teams.select{|team| team.vostok?}.length > 0 %>
-					<%= render 'public_teams_table', locals: {teams: teams,
-						selected_teams: teams.select{|team| team.vostok?},
-						selected_type: 'Vostok'} %>
-				<% else %>
-					No Data Available
-				<% end %>
-			</div>
-			<div id="project_gemini<%=cohort%>" class="tab-pane fade">
-				<% if teams.select{|team| team.project_gemini?}.length > 0 %>
-					<%= render 'public_teams_table', locals: {teams: teams,
-						selected_teams: teams.select{|team| team.project_gemini?},
-						selected_type: 'Project Gemini'} %>
-				<% else %>
-					No Data Available
-				<% end %>
-			</div>
-			<div id="apollo_11<%=cohort%>" class="tab-pane fade">
-				<% if teams.select{|team| team.apollo_11?}.length > 0 %>
-					<%= render 'public_teams_table', locals: {teams: teams,
-						selected_teams: teams.select{|team| team.apollo_11?},
-						selected_type: 'Apollo 11'} %>
-				<% else %>
-					No Data Available
-				<% end %>
-			</div>
-		</div>
+    <%= render 'public_cohort_projects', locals: {teams: teams, cohort: cohort} %>
 	</div>
 <% end %>
 </div>

--- a/app/views/public_views/public_projects/show.js.erb
+++ b/app/views/public_views/public_projects/show.js.erb
@@ -1,0 +1,39 @@
+/**
+ * This function will replace the "link_to" button (which does an ajax query to the server)
+ * with a non-ajax button. Doing so, will reduce the number of calls to the server.
+ */
+function switchToRenderedButton() {
+  $(`#toggle-${cohort}`).css('display', 'none');
+  $(`#rendered-toggle-${cohort}`).css('display', 'block');
+}
+
+var cohort = "<%=cohort%>";
+
+// Cohort toggle buttons
+$('.tab-button').each(function() {
+  if ($(this).children(`#toggle-${cohort}`).length > 0) {
+    $(this).addClass('active');
+  } else {
+    $(this).removeClass('active');
+  }
+})
+
+// Toggle between different cohort's project display
+var cohortIsRendered = false;
+$('#project-display').children('.tab-pane').each(function() {
+  if ($(this).attr('id') === cohort) {
+    cohortIsRendered = true;
+    $(this).addClass('in active');
+    switchToRenderedButton();
+  } else {
+    $(this).removeClass('in active');
+  }
+})
+if (!cohortIsRendered) {
+  $('#project-display').append(`
+    <div class='tab-pane fade in active' id=${cohort}>
+      <%=j render('public_cohort_projects', locals: {cohort: cohort, teams: teams}) %>
+    </div>
+  `);
+  switchToRenderedButton()
+}

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -101,7 +101,7 @@ Rails.application.routes.draw do
   resources :questions, only: [:create, :update, :destroy]
   resources :tags, only: [:index]
   namespace 'public_views' do
-    resources :public_projects, only: [:index]
+    resources :public_projects, only: [:index, :show]
     resources :public_staff, only: [:index]
     resources :group_carousel, only: [:index]
     resources :mentor_slides, only: [:index]


### PR DESCRIPTION
## Status
**IN DEVELOPMENT**

## Migrations
NO

## Description
Each cohort's project will be loaded upon clicking. Once loaded, whenever the cohort's button is clicked again, no more API calls will be made to the backend. 

## Fixes
 Fix #633 
