### PR TITLE
Get the latest milestone poster and video links

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,10 @@
+dist: trusty
 language: ruby
 rvm:
   - 2.3.3
+
+services:
+  - postgresql
 
 addons:
   postgresql: "9.3"

--- a/app/views/public_views/public_projects/_public_teams_table.html.erb
+++ b/app/views/public_views/public_projects/_public_teams_table.html.erb
@@ -34,7 +34,7 @@
   <div class="col-md-4 portfolio-item">
     <a role="button" onclick="createModalBox(<%= team.team_name %>)" id="button_<%= team.team_name %>">
       <% if !team.poster_link.blank? %>
-        <%= link_to image_tag(team.poster_link, size: "200", alt: "Team's Poster Link is not in image form", 
+        <%= link_to image_tag(team.poster_link, size: "200", alt: "Team's Poster Link is not in image form",
           title: "Click to view an enlarged version of this image.", id: "img_#{team.team_name}", onerror: "onerror=null;replaceImg(this, '#{team.project_level}')"), team.poster_link %>
       <% elsif locals[:selected_type] == 'Vostok' %>
         <%= image_tag("Vostok_Icon.jpg", size: "200", class: 'img-rounded inactive_link') %>
@@ -47,8 +47,8 @@
     <!-- createModalBox(<%= team.team_name %>) disabled if no submission present -->
     <!-- this assumes that submission has valid poster and video links -->
     <h3>
-      <% submission_local = Submission.where(team_id: team.id)[-1] %>
-      <% if (submission_local) %>
+      <% submissions = Submission.where(team_id: team.id).order(:milestone_id)%>
+      <% if not submissions.length == 0 %>
         <button class="button button_team" id="button_<%= team.id %>">
           <%= idx + 1 %>. <strong><%= team.team_name %></strong>
         </button>
@@ -72,19 +72,19 @@
       <hr>
       <h4 class="text-muted">Submission Links:</h4>
       <br>
-      <% if (submission_local) %>
-        <% if (!submission_local.video_link.blank?) %>
+      <% if not submissions.length == 0 %>
+        <% if not submissions[-1].video_link.blank? %>
           <div class="col-md-6">
-            <a role="button" class="button button_video" href="<%= Submission.where(team_id: team.id)[-1].video_link %>">
+            <a role="button" class="button button_video" href="<%= submissions[-1].video_link %>">
               Watch Project Video
             </a>
           </div>
         <% else %>
           <div>Video link is not submitted / not available.</div>
         <% end %>
-        <% if (!submission_local.poster_link.blank?) %>
+        <% if not submissions[-1].poster_link.blank? %>
           <div class="col-md-6">
-            <a role="button" class="button button_video" href="<%= Submission.where(team_id: team.id)[-1].poster_link %>">
+            <a role="button" class="button button_video" href="<%= submissions[-1].poster_link %>">
               View Project Poster
             </a>
           </div>


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
The PR aims to fix the links for the video and poster to reflect the latest Milestone submissions.

## Screenshots

#### Before:

![Before](https://user-images.githubusercontent.com/30969577/64121541-afa20280-cdd1-11e9-8ea7-be3e9a667656.gif)


#### After:

![After](https://user-images.githubusercontent.com/30969577/64121545-b2045c80-cdd1-11e9-8871-28d8cd7b20ff.gif)


## Steps to Test or Reproduce
* Go to the Projects page by clicking on the Project section within the navbar
* Click on the blue button for any team and then click 'Watch Project Video' and 'View Project Poster' (if these buttons are present) respectively.

## Fixes
Resolves Issue #742
