### PR TITLE
Remove publish checkbox

### DIFF
--- a/app/controllers/peer_evaluations_controller.rb
+++ b/app/controllers/peer_evaluations_controller.rb
@@ -162,7 +162,7 @@ class PeerEvaluationsController < ApplicationController
 
   def evaluation_params
     eval_params = params.require(:peer_evaluation).permit(
-      :public_content, :private_content, :submission_id, :published)
+      :public_content, :private_content, :submission_id)
     if params[:team_id]
       eval_params[:team_id] = params[:team_id]
     elsif params[:adviser_id]

--- a/app/views/peer_evaluations/_peer_evaluation_form.html.erb
+++ b/app/views/peer_evaluations/_peer_evaluation_form.html.erb
@@ -24,11 +24,6 @@
       <% end %>
     </div>
     <br>
-    <div class="checkbox" style="display: none;">
-      <label class="col-sm-offset-2">
-        <%= f.check_box :published, {}, 'true', 'false' %> Publish
-      </label>
-    </div>
     <div class="form-group">
       <div class="col-sm-offset-2 col-sm-10">
         <%= f.submit 'Submit', class: 'btn btn-success' %>

--- a/db/migrate/20190919124611_remove_published_from_peer_evaluations.rb
+++ b/db/migrate/20190919124611_remove_published_from_peer_evaluations.rb
@@ -1,0 +1,5 @@
+class RemovePublishedFromPeerEvaluations < ActiveRecord::Migration
+  def change
+    remove_column :peer_evaluations, :published, :boolean
+  end
+end

--- a/db/migrate/20190919124925_remove_published_from_submissions.rb
+++ b/db/migrate/20190919124925_remove_published_from_submissions.rb
@@ -1,0 +1,5 @@
+class RemovePublishedFromSubmissions < ActiveRecord::Migration
+  def change
+    remove_column :submissions, :published, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -120,7 +120,6 @@ ActiveRecord::Schema.define(version: 20190720031527) do
     t.text     "public_content"
     t.text     "private_content"
     t.datetime "created_at",                         null: false
-    t.boolean  "published"
     t.integer  "team_id"
     t.integer  "submission_id"
     t.integer  "adviser_id"
@@ -174,7 +173,6 @@ ActiveRecord::Schema.define(version: 20190720031527) do
   create_table "submissions", force: :cascade do |t|
     t.integer  "milestone_id",                     null: false
     t.integer  "team_id",                          null: false
-    t.boolean  "published",        default: false
     t.datetime "created_at",                       null: false
     t.datetime "updated_at",                       null: false
     t.string   "video_link"
@@ -182,7 +180,7 @@ ActiveRecord::Schema.define(version: 20190720031527) do
     t.text     "project_log"
     t.boolean  "show_public",      default: true
     t.string   "poster_link"
-    t.integer  "milestone_number", default: 0,     null: false 
+    t.integer  "milestone_number", default: 0,     null: false
   end
 
   add_index "submissions", ["milestone_id"], name: "index_submissions_on_milestone_id", using: :btree

--- a/spec/factories/peer_evaluations.rb
+++ b/spec/factories/peer_evaluations.rb
@@ -5,7 +5,6 @@ FactoryGirl.define do
     submission nil
     public_content '{q[1][1]: 5}'
     private_content '{q[5][1]: 5}'
-    published true
     owner_type 0
   end
 end

--- a/test/fixtures/peer_evaluations.yml
+++ b/test/fixtures/peer_evaluations.yml
@@ -4,7 +4,6 @@ peer_eval_1:
   id: 1
   created_at: <%= 0.days.from_now.to_s :db %>
   updated_at: <%= 0.days.from_now.to_s :db %>
-  published: false
   team_id: 1732
   submission_id: 1748
   owner_type: "teams"
@@ -14,7 +13,6 @@ peer_eval_2:
   id: 2
   created_at: <%= 0.days.from_now.to_s :db %>
   updated_at: <%= 0.days.from_now.to_s :db %>
-  published: false
   team_id: 1733
   submission_id: 1749
   owner_type: "teams"

--- a/test/fixtures/submissions.yml
+++ b/test/fixtures/submissions.yml
@@ -5,7 +5,6 @@ submission_1746:
   id: 1746
   milestone_id: 1
   team_id: 1731
-  published: false
   created_at: <%= 0.days.from_now.to_s :db %>
   updated_at: <%= 0.days.from_now.to_s :db %>
   poster_link: "https://i.ytimg.com/vi/RTfvXkEXa-k/maxresdefault.jpg"
@@ -18,7 +17,6 @@ submission_1747:
   id: 1747
   milestone_id: 2
   team_id: 1732
-  published: false
   created_at: <%= 0.days.from_now.to_s :db %>
   updated_at: <%= 0.days.from_now.to_s :db %>
   poster_link:
@@ -31,7 +29,6 @@ submission_1748:
   id: 1748
   milestone_id: 3
   team_id: 1733
-  published: false
   created_at: <%= 0.days.from_now.to_s :db %>
   updated_at: <%= 0.days.from_now.to_s :db %>
   poster_link:
@@ -44,7 +41,6 @@ submission_1749:
   id: 1749
   milestone_id: 1
   team_id: 1735
-  published: false
   created_at: <%= 0.days.from_now.to_s :db %>
   updated_at: <%= 0.days.from_now.to_s :db %>
   poster_link: "https://i.ytimg.com/vi/XlUPuj2V6PM/maxresdefault.jpg"
@@ -57,7 +53,6 @@ submission_1750:
   id: 1750
   milestone_id: 2
   team_id: 1735
-  published: false
   created_at: <%= 0.days.from_now.to_s :db %>
   updated_at: <%= 0.days.from_now.to_s :db %>
   poster_link:
@@ -70,7 +65,6 @@ submission_1751:
   id: 1751
   milestone_id: 3
   team_id: 1735
-  published: false
   created_at: <%= 0.days.from_now.to_s :db %>
   updated_at: <%= 0.days.from_now.to_s :db %>
   poster_link: "http://cdn.ebaumsworld.com/mediaFiles/picture/604025/84556534.jpg"
@@ -83,7 +77,6 @@ submission_1752:
   id: 1752
   milestone_id: 1
   team_id: 1738
-  published: false
   created_at: <%= 0.days.from_now.to_s :db %>
   updated_at: <%= 0.days.from_now.to_s :db %>
   poster_link: "https://i.ytimg.com/vi/xzWEJkh800o/maxresdefault.jpg"
@@ -96,7 +89,6 @@ submission_1753:
   id: 1753
   milestone_id: 2
   team_id: 1738
-  published: false
   created_at: <%= 0.days.from_now.to_s :db %>
   updated_at: <%= 0.days.from_now.to_s :db %>
   poster_link:
@@ -109,7 +101,6 @@ submission_1754:
   id: 1754
   milestone_id: 3
   team_id: 1738
-  published: false
   created_at: <%= 0.days.from_now.to_s :db %>
   updated_at: <%= 0.days.from_now.to_s :db %>
   poster_link:
@@ -122,7 +113,6 @@ submission_1755:
   id: 1755
   milestone_id: 2
   team_id: 1740
-  published: false
   created_at: <%= 0.days.from_now.to_s :db %>
   updated_at: <%= 0.days.from_now.to_s :db %>
   poster_link: "http://breadnmolasses.com/wp-content/uploads/2009/04/1755-logo-petit-300x260.jpg"


### PR DESCRIPTION
## Status
**READY**

## Migrations
YES

## Description
The checkbox was introduced in this commit: e3678e0941994a030cf5d3f3b6e019f960651905. The change was most probably intended to allow toggling between the states where the peer evaluations can/cannot be viewed by the student that the evaluation was submitted for.

However, after doing a search of the codebase, I couldn't find an instance where this published state was being used. Furthermore, whether you select/unselect that option the peer evaluation is still visible to the student. Hence, I decided to remove the publish button, `published` field and   associated dependencies.

## Deploy Notes
I've created two migrations:
1) 20190919124611_remove_published_from_peer_evaluations.rb
2) 20190919124925_remove_published_from_submissions.rb

The two migrations delete the published field from the Peer Evaluations and Submissions tables respectively.

## Fixes
Closes #745 
