### PR TITLE
Show dropped teams as strikethrough text button at adviser home page

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 dist: trusty
 language: ruby
+before_install:
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler -v '< 2'
 rvm:
   - 2.3.3
 

--- a/app/views/advisers/_adviser_teams.html.erb
+++ b/app/views/advisers/_adviser_teams.html.erb
@@ -1,20 +1,26 @@
 <div class="table-responsive">
   <table class="table table-hover">
     <thead>
-    <tr>
-      <th>Team Name</th>
-      <th>Level of achievement</th>
-      <% locals[:milestones].each do |milestone| %>
-        <th><%= milestone.name %> evaluations</th>
-      <% end %>
-      <th>Action</th>
-    </tr>
+      <tr>
+        <th>Team Name</th>
+        <th>Level of achievement</th>
+        <% locals[:milestones].each do |milestone| %>
+          <th><%= milestone.name %> evaluations</th>
+        <% end %>
+        <th>Action</th>
+      </tr>
     </thead>
     <tbody>
     <% locals[:adviser].teams.each do |team| %>
       <tr>
         <td>
-          <a href="<%= team_path(team) %>" class="btn btn-info"><%= team.team_name %></a>
+          <% if team.has_dropped %>
+            <a class="btn btn-info" data-toggle="tooltip" data-placement="top" title="<%= I18n.t('teams.has_dropped_tooltip') %>" disabled>
+              <del><%= team.team_name %></del>
+            </a>
+          <% else %>
+            <a href="<%= team_path(team) %>" class="btn btn-info"><%= team.team_name %></a>
+          <% end %>
         </td>
         <td>
           <%= team.get_project_level %>
@@ -33,7 +39,14 @@
                 <a href="<%= milestone_team_peer_evaluation_path(milestone.id, evaluated.evaluator_id, peer_evaluation_id) %>" class="btn btn-info"><%= evaluated.evaluated.team_name %></a>
                 <br> <br>
               <% else %>
-                <a class="btn btn-default" disabled="disabled"><%= evaluated.evaluated.team_name %></a> <br><br>
+                <% if evaluated.evaluated.has_dropped %>
+                  <a class="btn btn-default" data-toggle="tooltip" data-placement="top" title="<%= I18n.t('teams.has_dropped_tooltip') %>" disabled>
+                    <del><%= evaluated.evaluated.team_name %></del>
+                  </a>
+                  <br><br>
+                <% else %>
+                  <a class="btn btn-default" disabled="disabled"><%= evaluated.evaluated.team_name %></a> <br><br>
+                <% end %>
               <% end %>
             <% end %>
           </td>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -79,6 +79,8 @@ en:
       failure_message: >
         Admin could not be deleted: <br>&nbsp;&nbsp;&nbsp;&nbsp;%{error_message}
   advisers:
+    evaluator_has_dropped_tooltip: >
+      This evaluator team has dropped from Orbital.
     index:
       page_title: >
         View all advisers


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
I make some minor changes by disabling adviser to click on dropped team and display as strikethrough text button. In addition, any future milestones peer evaluations will be considered disabled and strikethrough button.

## Screenshots
Add screenshots to [summarize the UI changes (if any)](https://github.com/nusskylab/nusskylab/pull/692#pullrequestreview-236562760)

#### Before:
![Screenshot 2020-02-15 at 17 06 03](https://user-images.githubusercontent.com/5901764/74585236-7e329180-5015-11ea-9c5f-7799341090b5.png)
(This is taken from the production website on 1 of the previous adviser which 1 of his/her team dropped from Orbital) 

#### After:
![Screenshot 2020-02-15 at 16 56 54](https://user-images.githubusercontent.com/5901764/74585178-dae17c80-5014-11ea-889f-a93400e9a74f.png)

## Steps to Test or Reproduce
Select any adviser's view all teams panel.

## Fixes
* #785
