### PR TITLE
Reordering of staff display

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 dist: trusty
 language: ruby
+before_install:
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler -v '< 2'
 rvm:
   - 2.3.3
 

--- a/app/controllers/public_views/public_staff_controller.rb
+++ b/app/controllers/public_views/public_staff_controller.rb
@@ -29,10 +29,5 @@ class PublicViews::PublicStaffController < ApplicationController
     @staff = staff_table
     @cohort = cohort
     @all_cohorts = all_cohorts
-
-    respond_to do |format|
-        format.html
-        format.js
-    end
   end
 end

--- a/app/controllers/public_views/public_staff_controller.rb
+++ b/app/controllers/public_views/public_staff_controller.rb
@@ -26,8 +26,10 @@ class PublicViews::PublicStaffController < ApplicationController
     staff_table[:advisers] = advisers
     staff_table[:mentors] = mentors
     staff_table[:tutors] = tutors
-    @staff = staff_table
-    @cohort = cohort
-    @all_cohorts = all_cohorts
+    render locals: {
+      staff: staff_table,
+      cohort: cohort,
+      all_cohorts: all_cohorts
+    }
   end
 end

--- a/app/controllers/public_views/public_staff_controller.rb
+++ b/app/controllers/public_views/public_staff_controller.rb
@@ -4,9 +4,14 @@ class PublicViews::PublicStaffController < ApplicationController
     !authenticate_user(false, false) && return
     @page_title = t('.page_title')
     cohort = params[:cohort] || current_cohort
-    facilitators = Facilitator.where(
-      cohort: cohort
-    ).joins(:user).order('user_name')
+    sort_by = params[:sort_by]
+    if sort_by.nil?
+      facilitators = Facilitator.where(
+          cohort: cohort
+        ).joins(:user).order('user_name')
+    else
+      facilitators = Facilitator.sort(sort_by)
+    end
     advisers = Adviser.where(
       cohort: cohort
     ).joins(:user).order('user_name')
@@ -21,10 +26,13 @@ class PublicViews::PublicStaffController < ApplicationController
     staff_table[:advisers] = advisers
     staff_table[:mentors] = mentors
     staff_table[:tutors] = tutors
-    render locals: {
-      staff: staff_table,
-      cohort: cohort,
-      all_cohorts: all_cohorts
-    }
+    @staff = staff_table
+    @cohort = cohort
+    @all_cohorts = all_cohorts
+
+    respond_to do |format|
+        format.html
+        format.js
+    end
   end
 end

--- a/app/models/facilitator.rb
+++ b/app/models/facilitator.rb
@@ -7,4 +7,21 @@ class Facilitator < ActiveRecord::Base
     scope: :cohort,
     message: 'can only have one facilitator role for each cohort'
   }
+
+  def Facilitator.sort(sort_by)
+    case sort_by
+    when 'name'
+      Facilitator.where(
+        cohort: 2020
+      ).joins(:user).order(user_id: :asc)
+    when 'oldest'
+      Facilitator.where(
+        cohort: 2020
+      ).joins(:user).order(created_at: :asc)
+    when 'newest'
+      Facilitator.where(
+        cohort: 2020
+      ).joins(:user).order(created_at: :desc)
+    end
+  end
 end

--- a/app/models/facilitator.rb
+++ b/app/models/facilitator.rb
@@ -22,6 +22,10 @@ class Facilitator < ActiveRecord::Base
       Facilitator.where(
         cohort: 2020
       ).joins(:user).order(created_at: :desc)
+    when 'display_order'
+      Facilitator.where(
+        cohort: 2020
+      ).joins(:user).order(display_order: :asc)
     end
   end
 end

--- a/app/views/public_views/public_staff/_user_roles.html.erb
+++ b/app/views/public_views/public_staff/_user_roles.html.erb
@@ -10,7 +10,7 @@
     <% if locals[:roles] && locals[:roles].length > 0 %>
       <% locals[:roles].each do |role| %>
         <!-- Filters out sample data ending with @example.com -->
-        <% #if not role.user.email.end_with? "@example.com" %>
+        <% if not role.user.email.end_with? "@example.com" %>
           <div class="row">
             <div class="col-md-3">
               <%= image_tag role.user.gravatar_url(size: 150) %>
@@ -28,7 +28,7 @@
             </div>
           </div>
           <br><hr><br>
-        <% #end %>
+        <% end %>
       <% end %>
     <% else %>
       No data to show

--- a/app/views/public_views/public_staff/_user_roles.html.erb
+++ b/app/views/public_views/public_staff/_user_roles.html.erb
@@ -10,7 +10,7 @@
     <% if locals[:roles] && locals[:roles].length > 0 %>
       <% locals[:roles].each do |role| %>
         <!-- Filters out sample data ending with @example.com -->
-        <% if not role.user.email.end_with? "@example.com" %>
+        <% #if not role.user.email.end_with? "@example.com" %>
           <div class="row">
             <div class="col-md-3">
               <%= image_tag role.user.gravatar_url(size: 150) %>
@@ -28,7 +28,7 @@
             </div>
           </div>
           <br><hr><br>
-        <% end %>
+        <% #end %>
       <% end %>
     <% else %>
       No data to show

--- a/app/views/public_views/public_staff/index.html.erb
+++ b/app/views/public_views/public_staff/index.html.erb
@@ -10,22 +10,32 @@
       <div class="panel panel-default">
         <div class="panel-heading">
           <h2 class="text-center">
-            Staff in Cohort <%= cohort %>
+            Staff in Cohort <%= @cohort %>
           </h2>
         </div>
         <div class="panel-body">
-          <% if staff %>
+          <% if @staff %>
             <div id="facilitators">
-              <%= render 'user_roles', locals: {roles: staff[:facilitators].reorder(:display_order), selected_type: 'Facilitators'} %>
+              <div class="dropdown" align="right">
+                <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                  Sort By
+                </button>
+                <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton">
+                  <li><%= link_to "Newest", public_views_public_staff_index_path(sort_by: :newest), remote: true, class: 'dropdown-item' %></li>
+                  <li><%= link_to "Oldest", public_views_public_staff_index_path(sort_by: :oldest), remote: true, class: 'dropdown-item' %></li>
+                  <li><%= link_to "Name", public_views_public_staff_index_path(sort_by: :name), remote: true, class: 'dropdown-item' %></li>
+                </div>
+              </div>
+              <%= render 'user_roles', locals: {roles: @staff[:facilitators].reorder(:display_order), selected_type: 'Facilitators'} %>
             </div>
             <div id="advisers">
-              <%= render 'user_roles', locals: {roles: staff[:advisers], selected_type: 'Advisers'} %>
+              <%= render 'user_roles', locals: {roles: @staff[:advisers], selected_type: 'Advisers'} %>
             </div>
             <div id="mentors">
-              <%= render 'user_roles', locals: {roles: staff[:mentors], selected_type: 'Mentors'} %>
+              <%= render 'user_roles', locals: {roles: @staff[:mentors], selected_type: 'Mentors'} %>
             </div>
             <div id="tutors">
-              <%= render 'user_roles', locals: {roles: staff[:tutors], selected_type: 'Tutors'} %>
+              <%= render 'user_roles', locals: {roles: @staff[:tutors], selected_type: 'Tutors'} %>
             </div>
           <% else %>
             No Data Available
@@ -33,7 +43,7 @@
         </div>
       </div>
       <div class="col-sm-12">
-        <% all_cohorts.each do |cohort| %>
+        <% @all_cohorts.each do |cohort| %>
         <div class="col-sm-2">
           <%= link_to cohort, public_views_public_staff_index_path(cohort: cohort), class: 'btn btn-info' %>
         </div>

--- a/app/views/public_views/public_staff/index.html.erb
+++ b/app/views/public_views/public_staff/index.html.erb
@@ -10,11 +10,11 @@
       <div class="panel panel-default">
         <div class="panel-heading">
           <h2 class="text-center">
-            Staff in Cohort <%= @cohort %>
+            Staff in Cohort <%= cohort %>
           </h2>
         </div>
         <div class="panel-body">
-          <% if @staff %>
+          <% if staff %>
             <div class="dropdown" align="right">
               <button class="btn btn-primary dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                 Sort By
@@ -27,16 +27,16 @@
               </div>
             </div>
             <div id="facilitators">
-              <%= render 'user_roles', locals: {roles: @staff[:facilitators].reorder(:display_order), selected_type: 'Facilitators'} %>
+              <%= render 'user_roles', locals: {roles: staff[:facilitators].reorder(:display_order), selected_type: 'Facilitators'} %>
             </div>
             <div id="advisers">
-              <%= render 'user_roles', locals: {roles: @staff[:advisers], selected_type: 'Advisers'} %>
+              <%= render 'user_roles', locals: {roles: staff[:advisers], selected_type: 'Advisers'} %>
             </div>
             <div id="mentors">
-              <%= render 'user_roles', locals: {roles: @staff[:mentors], selected_type: 'Mentors'} %>
+              <%= render 'user_roles', locals: {roles: staff[:mentors], selected_type: 'Mentors'} %>
             </div>
             <div id="tutors">
-              <%= render 'user_roles', locals: {roles: @staff[:tutors], selected_type: 'Tutors'} %>
+              <%= render 'user_roles', locals: {roles: staff[:tutors], selected_type: 'Tutors'} %>
             </div>
           <% else %>
             No Data Available
@@ -44,7 +44,7 @@
         </div>
       </div>
       <div class="col-sm-12">
-        <% @all_cohorts.each do |cohort| %>
+        <% all_cohorts.each do |cohort| %>
         <div class="col-sm-2">
           <%= link_to cohort, public_views_public_staff_index_path(cohort: cohort), class: 'btn btn-info' %>
         </div>

--- a/app/views/public_views/public_staff/index.html.erb
+++ b/app/views/public_views/public_staff/index.html.erb
@@ -17,7 +17,7 @@
           <% if @staff %>
             <div id="facilitators">
               <div class="dropdown" align="right">
-                <button class="btn btn-secondary dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                <button class="btn btn-primary dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
                   Sort By
                 </button>
                 <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton">

--- a/app/views/public_views/public_staff/index.html.erb
+++ b/app/views/public_views/public_staff/index.html.erb
@@ -15,17 +15,18 @@
         </div>
         <div class="panel-body">
           <% if @staff %>
-            <div id="facilitators">
-              <div class="dropdown" align="right">
-                <button class="btn btn-primary dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                  Sort By
-                </button>
-                <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton">
-                  <li><%= link_to "Newest", public_views_public_staff_index_path(sort_by: :newest), remote: true, class: 'dropdown-item' %></li>
-                  <li><%= link_to "Oldest", public_views_public_staff_index_path(sort_by: :oldest), remote: true, class: 'dropdown-item' %></li>
-                  <li><%= link_to "Name", public_views_public_staff_index_path(sort_by: :name), remote: true, class: 'dropdown-item' %></li>
-                </div>
+            <div class="dropdown" align="right">
+              <button class="btn btn-primary dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                Sort By
+              </button>
+              <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton">
+                <li><%= link_to "Newest", public_views_public_staff_index_path(sort_by: :newest), remote: true, class: 'dropdown-item' %></li>
+                <li><%= link_to "Oldest", public_views_public_staff_index_path(sort_by: :oldest), remote: true, class: 'dropdown-item' %></li>
+                <li><%= link_to "Name", public_views_public_staff_index_path(sort_by: :name), remote: true, class: 'dropdown-item' %></li>
+                <li><%= link_to "Display Order", public_views_public_staff_index_path(sort_by: :display_order), remote: true, class: 'dropdown-item' %></li>
               </div>
+            </div>
+            <div id="facilitators">
               <%= render 'user_roles', locals: {roles: @staff[:facilitators].reorder(:display_order), selected_type: 'Facilitators'} %>
             </div>
             <div id="advisers">

--- a/app/views/public_views/public_staff/index.js.erb
+++ b/app/views/public_views/public_staff/index.js.erb
@@ -1,1 +1,1 @@
-$('#facilitators').html("<%= escape_javascript(render(partial: 'user_roles', locals: { roles: @staff[:facilitators], selected_type: 'Facilitators' })) %>");
+$('#facilitators').html("<%= escape_javascript(render 'user_roles', locals: { selected_type: 'Facilitators', roles: @staff[:facilitators] }) %>");

--- a/app/views/public_views/public_staff/index.js.erb
+++ b/app/views/public_views/public_staff/index.js.erb
@@ -1,0 +1,1 @@
+$('#facilitators').html("<%= escape_javascript(render(partial: 'user_roles', locals: { roles: @staff[:facilitators], selected_type: 'Facilitators' })) %>");

--- a/app/views/public_views/public_staff/index.js.erb
+++ b/app/views/public_views/public_staff/index.js.erb
@@ -1,1 +1,1 @@
-$('#facilitators').html("<%= escape_javascript(render 'user_roles', locals: { selected_type: 'Facilitators', roles: @staff[:facilitators] }) %>");
+$('#facilitators').html("<%= escape_javascript(render 'user_roles', locals: { selected_type: 'Facilitators', roles: staff[:facilitators] }) %>");


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
Used AJAX to sort the facilitators base on time created, name and display order. 
## Screenshots
Add screenshots to [summarize the UI changes (if any)](https://github.com/nusskylab/nusskylab/pull/692#pullrequestreview-236562760)

#### Before:
<img width="948" alt="before" src="https://user-images.githubusercontent.com/45935526/74605518-b6180280-5103-11ea-82fc-a2776d00cf5a.png">

#### After:
<img width="922" alt="Screenshot 2020-02-21 at 11 42 07 PM" src="https://user-images.githubusercontent.com/45935526/75049439-260ff980-5505-11ea-85fe-8f9a4d2e7c85.png">

