### PR TITLE
Fix travis bundler error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,7 @@
 dist: trusty
 language: ruby
+before_install:
+  - gem install bundler
 rvm:
   - 2.3.3
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,8 @@
 dist: trusty
 language: ruby
 before_install:
-  - bundle update --bundler
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler -v '< 2'
 rvm:
   - 2.3.3
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 dist: trusty
 language: ruby
 before_install:
-  - gem install bundler
+  - bundle update --bundler
 rvm:
   - 2.3.3
 


### PR DESCRIPTION
## Status
**READY

## Migrations
NO

## Description
travis failing due to Could not find 'bundler' (1.16.2) required by your /home/travis/build/nusskylab/nusskylab/Gemfile.lock. (Gem::GemNotFoundException)

## Screenshots
Add screenshots to [summarize the UI changes (if any)](https://github.com/nusskylab/nusskylab/pull/692#pullrequestreview-236562760)

#### Before:
Add screenshot showing the current state of Skylab (in sync with the master branch)

#### After:
Add screenshot showing the UI changes made by your PR

 
## Related PRs
List related PRs against other branches:

## Todos
- [ ] Tests
- [ ] Documentation


## Deploy Notes
Notes regarding deployment the contained body of work.  These should note any
db migrations, etc.

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

## Fixes

* added   
before_install:
    - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
    - gem install bundler -v '< 2'

to travis.yml