### PR TITLE
Ease of changing level of achievement of teams

### DIFF
--- a/app/views/teams/_team_form.html.erb
+++ b/app/views/teams/_team_form.html.erb
@@ -2,7 +2,13 @@
                     url: {action: (locals[:is_new] ? 'create' : 'update')}) do |f| %>
   <%= f.error_notification %>
   <%= f.input :team_name %>
-  <% if is_project_level_locked? %>
+  <% if current_user_admin? %>
+    <%= f.input :project_level, collection: {Vostok: 'Vostok',
+                                            'Project Gemini'.to_sym => 'Project Gemini',
+                                            'Apollo 11'.to_sym => 'Apollo 11'},
+                                selected: locals[:team].get_project_level,
+                                include_blank: false, required: true %>
+  <% elsif is_project_level_locked? %>
     <div class="form-group string required team_team_name">
       <label class="string required col-sm-3 control-label"> Project level </label>
       <div class="col-sm-9">


### PR DESCRIPTION
… swap status

## Status
**READY**

## Migrations
NO

## Description
Allows admins to change level of achievement of teams during editing/creating without dealing with Project Level Swap Status.

## Screenshots
<img width="1203" alt="Screenshot 2020-02-21 at 3 37 40 AM" src="https://user-images.githubusercontent.com/42717486/74971889-c3165800-545b-11ea-8b35-9aeb5237f770.png">
<img width="1219" alt="Screenshot 2020-02-21 at 3 37 57 AM" src="https://user-images.githubusercontent.com/42717486/74971892-c578b200-545b-11ea-964b-cf90a45eaae0.png">
<img width="1193" alt="Screenshot 2020-02-21 at 3 38 11 AM" src="https://user-images.githubusercontent.com/42717486/74971899-c7db0c00-545b-11ea-9e9d-3311eecd74a0.png">
 
## Related PRs
#773 

## Todos
- [x] Tests

## Deploy Notes
-

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

## Fixes
Added an if clause to check if current user is an admin
