### PR TITLE
[iss771]The star before Adviser and Status in the team creation form should be removed.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,10 @@
 dist: trusty
 language: ruby
+
+before_install:
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler -v '< 2'
+
 rvm:
   - 2.3.3
 

--- a/app/views/teams/_team_form.html.erb
+++ b/app/views/teams/_team_form.html.erb
@@ -17,7 +17,7 @@
                                 include_blank: false, required: true %>
   <% end %>
   <% if current_user_admin? %>
-    <%= f.input :adviser_id, collection: locals[:advisers].map {|adviser| [adviser.user.user_name, adviser.id]}, include_blank: 'Not assigned', required: true %>
+    <%= f.input :adviser_id, collection: locals[:advisers].map {|adviser| [adviser.user.user_name, adviser.id]}, include_blank: 'Not assigned' %>
     <%= f.input :mentor_id, collection: locals[:mentors].map {|mentor| [mentor.user.user_name, mentor.id]}, include_blank: 'Not assigned' %>
   <% end %>
   <% if current_user_admin? or current_user_adviser? or current_user_student? %>
@@ -28,7 +28,7 @@
     <%= f.input :status, collection: {'No Status'.to_sym => 0, 'Contactable and doing well'.to_sym => 1, 'Contactable but lack of progress'.to_sym => 2,
                                       Uncontactable: 3, 'To be re-evaluated': 4},
                                       selected: locals[:team].status,
-                                      include_blank: false, required: true %>
+                                      include_blank: false %>
     <%= f.input :comment, placeholder: true, placeholder: 'Enter comments and include your name' %>
   <% end %>
   <% if locals[:is_new] %>

--- a/config/locales/simple_form.en.yml
+++ b/config/locales/simple_form.en.yml
@@ -3,7 +3,7 @@ en:
     "yes": 'Yes'
     "no": 'No'
     required:
-      text: 'required'
+      text: 'Required'
       mark: '*'
       # You can uncomment the line below if you need to overwrite the whole required html.
       # When using html, text and mark won't be used.


### PR DESCRIPTION
## Status
**READY

## Migrations
NO

## Description

Removing the asterisks from the Advisor field and Status field from the team creation form.

## Screenshots
Add screenshots to [summarize the UI changes (if any)](https://github.com/nusskylab/nusskylab/pull/692#pullrequestreview-236562760)

#### Before:
<img width="1020" alt="Screenshot 2020-02-21 at 7 53 08 PM" src="https://user-images.githubusercontent.com/42350195/75032547-cbb27100-54e3-11ea-8cf0-4b408f28c966.png">

#### After:
<img width="1020" alt="Screenshot 2020-02-21 at 7 40 25 PM" src="https://user-images.githubusercontent.com/42350195/75031796-05827800-54e2-11ea-894e-bd893fcd9094.png">

 
## Related PRs
- 

## Todos
- [ ] Tests
- [ ] Documentation


## Deploy Notes
Notes regarding deployment the contained body of work.  These should note any
db migrations, etc.

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

## Fixes

* Remove `required: true` attribute from f.input of :advisor_id and :status in the _team_form.html.erb
