### PR TITLE
#769 project gallery does not display 2020 cohort

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,8 @@
 dist: trusty
 language: ruby
+before_install:
+  - gem uninstall -v '>= 2' -i $(rvm gemdir)@global -ax bundler || true
+  - gem install bundler -v '< 2'
 rvm:
   - 2.3.3
 

--- a/app/controllers/cohort_helper.rb
+++ b/app/controllers/cohort_helper.rb
@@ -5,6 +5,10 @@ module CohortHelper
   end
 
   def all_cohorts
-    [2020, 2019, 2018, 2017, 2016, 2015, 2014, 2013]
+    arr = []
+    for year in 2013 .. current_cohort do
+      arr.push(year)
+    end
+    return arr.reverse()
   end
 end

--- a/app/controllers/cohort_helper.rb
+++ b/app/controllers/cohort_helper.rb
@@ -5,6 +5,6 @@ module CohortHelper
   end
 
   def all_cohorts
-    [2019, 2018, 2017, 2016, 2015, 2014, 2013]
+    [2020, 2019, 2018, 2017, 2016, 2015, 2014, 2013]
   end
 end

--- a/app/views/public_views/public_projects/_public_teams_table.html.erb
+++ b/app/views/public_views/public_projects/_public_teams_table.html.erb
@@ -66,9 +66,7 @@
   <div id="modal_<%= team.id %>" class="modal">
     <div class="modal-content">
       <span class="close">&times;</span>
-      <center>
-        <h4 class="text-muted"><%= team.team_name %></h4>
-      </center>
+      <h4 class="text-muted" style="text-align: center"><%= team.team_name %></h4>
       <hr>
       <h4 class="text-muted">Submission Links:</h4>
       <br>


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
Updated the all_cohorts function to return an array from 2013 to the current year.

## Screenshots
Add screenshots to [summarize the UI changes (if any)](https://github.com/nusskylab/nusskylab/pull/692#pullrequestreview-236562760)

#### Before:
![image](https://user-images.githubusercontent.com/45462587/75085396-a8c7a180-5563-11ea-8432-fbd4d03e26b0.png)


#### After:
![image](https://user-images.githubusercontent.com/45462587/75085389-93527780-5563-11ea-8301-aba17f2d9ca4.png)

 
## Related PRs
List related PRs against other branches:

## Todos
- [ ] Tests
- [ ] Documentation


## Deploy Notes
Notes regarding deployment the contained body of work.  These should note any
db migrations, etc.

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.


## Fixes
The project gallery now shows projects up to the current year.
* 
