### PR TITLE
Added in Artemis option in Teams and Projects page

### DIFF
--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -28,7 +28,8 @@ class Team < ActiveRecord::Base
   VOSTOK_REGEX = /\A(?:v)|(?:vostok)\z/
   PROJECT_GEMINI_REGEX = /\A(?:project gemini)|(?:gemini)|(?:g)\z/
   APOLLO_11_REGEX = /\A(?:apollo 11)|(?:apollo)|(?:a)\z/
-  enum project_level: [:vostok, :project_gemini, :apollo_11]
+  ARTEMIS_REGEX = /\A(?:a)|(?:artemis)\z/
+  enum project_level: [:vostok, :project_gemini, :apollo_11, :artemis]
 
   def self.to_csv(**options)
     require 'csv'
@@ -117,6 +118,8 @@ class Team < ActiveRecord::Base
       Team.project_levels[:project_gemini]
     elsif project_level[APOLLO_11_REGEX]
       Team.project_levels[:apollo_11]
+    elsif project_level[ARTEMIS_REGEX]
+      Team.project_levels[:artemis]
     end
   end
 

--- a/app/views/public_views/public_projects/index.html.erb
+++ b/app/views/public_views/public_projects/index.html.erb
@@ -17,6 +17,7 @@
 			<li class="active"><a data-toggle="pill" href="#vostok<%=cohort%>">Vostok</a></li>
 			<li><a data-toggle="pill" href="#project_gemini<%=cohort%>">Project Gemini</a></li>
 			<li><a data-toggle="pill" href="#apollo_11<%=cohort%>">Apollo 11</a></li>
+			<li><a data-toggle="pill" href="#artemis<%=cohort%>">Artemis</a></li>
 		</ul>
 		<div class="tab-content">
 			<div id="vostok<%=cohort%>" class="tab-pane fade in active">
@@ -42,6 +43,15 @@
 					<%= render 'public_teams_table', locals: {teams: teams,
 						selected_teams: teams.select{|team| team.apollo_11?},
 						selected_type: 'Apollo 11'} %>
+				<% else %>
+					No Data Available
+				<% end %>
+			</div>
+			<div id="artemis<%=cohort%>" class="tab-pane fade">
+				<% if teams.select{|team| team.artemis?}.length > 0 %>
+					<%= render 'public_teams_table', locals: {teams: teams,
+						selected_teams: teams.select{|team| team.artemis?},
+						selected_type: 'Artemis'} %>
 				<% else %>
 					No Data Available
 				<% end %>

--- a/app/views/teams/_team_form.html.erb
+++ b/app/views/teams/_team_form.html.erb
@@ -12,7 +12,8 @@
   <% else %>
     <%= f.input :project_level, collection: {Vostok: 'Vostok',
                                             'Project Gemini'.to_sym => 'Project Gemini',
-                                            'Apollo 11'.to_sym => 'Apollo 11'},
+                                            'Apollo 11'.to_sym => 'Apollo 11',
+                                            'Artemis'.to_sym => 'Artemis'},
                                 selected: locals[:team].get_project_level,
                                 include_blank: false, required: true %>
   <% end %>


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
Under the Team Creation page, the Artemis option has been added as a drop down option in the project level field in the form. Under the public project page, the Artemis tab has been added to showcase projects of the Artemis level. 

## Screenshots
(https://github.com/nusskylab/nusskylab/pull/692#pullrequestreview-236562760)

#### Before:
Add screenshot showing the current state of Skylab (in sync with the master branch)

#### After:
![image](https://user-images.githubusercontent.com/32284166/75031792-04514b00-54e2-11ea-92d5-f9ff4d21a3f8.png)
Added in the Artemis option in the drop down of Team Creation form. 

![image](https://user-images.githubusercontent.com/32284166/75033468-f4d40100-54e5-11ea-9dd1-494d2f23c4fe.png)
Added the Artemis tag in the Project Gallery page.

## Related PRs
List related PRs against other branches:

## Todos
- [X] Tests
- [ ] Documentation

