### PR TITLE
Reordering staff display

### DIFF
--- a/app/controllers/public_views/public_staff_controller.rb
+++ b/app/controllers/public_views/public_staff_controller.rb
@@ -4,9 +4,14 @@ class PublicViews::PublicStaffController < ApplicationController
     !authenticate_user(false, false) && return
     @page_title = t('.page_title')
     cohort = params[:cohort] || current_cohort
-    facilitators = Facilitator.where(
-      cohort: cohort
-    ).joins(:user).order('user_name')
+    sort_by = params[:sort_by]
+    if sort_by.nil?
+      facilitators = Facilitator.where(
+        cohort: cohort
+      ).joins(:user).order('user_name')
+    else
+      facilitators = Facilitator.sort(sort_by)
+    end
     advisers = Adviser.where(
       cohort: cohort
     ).joins(:user).order('user_name')

--- a/app/controllers/public_views/public_staff_controller.rb
+++ b/app/controllers/public_views/public_staff_controller.rb
@@ -6,11 +6,9 @@ class PublicViews::PublicStaffController < ApplicationController
     cohort = params[:cohort] || current_cohort
     sort_by = params[:sort_by]
     if sort_by.nil?
-      facilitators = Facilitator.where(
-        cohort: cohort
-      ).joins(:user).order('user_name')
+      facilitators = Facilitator.sort('display_order', cohort)
     else
-      facilitators = Facilitator.sort(sort_by)
+      facilitators = Facilitator.sort(sort_by, cohort)
     end
     advisers = Adviser.where(
       cohort: cohort

--- a/app/models/facilitator.rb
+++ b/app/models/facilitator.rb
@@ -14,14 +14,6 @@ class Facilitator < ActiveRecord::Base
       Facilitator.where(
         cohort: cohort
       ).joins(:user).order('user_name')
-    when 'oldest'
-      Facilitator.where(
-        cohort: cohort
-      ).joins(:user).order('created_at ASC')
-    when 'newest'
-      Facilitator.where(
-        cohort: cohort
-      ).joins(:user).order('created_at DESC')
     when 'display_order'
       Facilitator.where(
         cohort: cohort

--- a/app/models/facilitator.rb
+++ b/app/models/facilitator.rb
@@ -8,24 +8,24 @@ class Facilitator < ActiveRecord::Base
     message: 'can only have one facilitator role for each cohort'
   }
 
-  def Facilitator.sort(sort_by)
+  def Facilitator.sort(sort_by, cohort)
     case sort_by
     when 'name'
       Facilitator.where(
-        cohort: 2020
-      ).joins(:user).order(user_id: :asc)
+        cohort: cohort
+      ).joins(:user).order('user_name')
     when 'oldest'
       Facilitator.where(
-        cohort: 2020
-      ).joins(:user).order(created_at: :asc)
+        cohort: cohort
+      ).joins(:user).order('created_at ASC')
     when 'newest'
       Facilitator.where(
-        cohort: 2020
-      ).joins(:user).order(created_at: :desc)
+        cohort: cohort
+      ).joins(:user).order('created_at DESC')
     when 'display_order'
       Facilitator.where(
-        cohort: 2020
-      ).joins(:user).order(display_order: :asc)
+        cohort: cohort
+      ).joins(:user).order('display_order ASC, user_name')
     end
   end
 end

--- a/app/models/facilitator.rb
+++ b/app/models/facilitator.rb
@@ -7,4 +7,25 @@ class Facilitator < ActiveRecord::Base
     scope: :cohort,
     message: 'can only have one facilitator role for each cohort'
   }
+
+  def Facilitator.sort(sort_by)
+    case sort_by
+    when 'name'
+      Facilitator.where(
+        cohort: 2020
+      ).joins(:user).order(user_id: :asc)
+    when 'oldest'
+      Facilitator.where(
+        cohort: 2020
+      ).joins(:user).order(created_at: :asc)
+    when 'newest'
+      Facilitator.where(
+        cohort: 2020
+      ).joins(:user).order(created_at: :desc)
+    when 'display_order'
+      Facilitator.where(
+        cohort: 2020
+      ).joins(:user).order(display_order: :asc)
+    end
+  end
 end

--- a/app/views/public_views/public_staff/index.html.erb
+++ b/app/views/public_views/public_staff/index.html.erb
@@ -15,6 +15,17 @@
         </div>
         <div class="panel-body">
           <% if staff %>
+            <div class="dropdown" align="right">
+              <button class="btn btn-primary dropdown-toggle" type="button" id="dropdownMenuButton" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                Sort By
+              </button>
+              <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton">
+                <li><%= link_to "Newest", public_views_public_staff_index_path(sort_by: :newest), remote: true, class: 'dropdown-item' %></li>
+                <li><%= link_to "Oldest", public_views_public_staff_index_path(sort_by: :oldest), remote: true, class: 'dropdown-item' %></li>
+                <li><%= link_to "Name", public_views_public_staff_index_path(sort_by: :name), remote: true, class: 'dropdown-item' %></li>
+                <li><%= link_to "Display Order", public_views_public_staff_index_path(sort_by: :display_order), remote: true, class: 'dropdown-item' %></li>
+              </div>
+            </div>
             <div id="facilitators">
               <%= render 'user_roles', locals: {roles: staff[:facilitators].reorder(:display_order), selected_type: 'Facilitators'} %>
             </div>

--- a/app/views/public_views/public_staff/index.html.erb
+++ b/app/views/public_views/public_staff/index.html.erb
@@ -20,10 +20,8 @@
                 Sort By
               </button>
               <div class="dropdown-menu dropdown-menu-right" aria-labelledby="dropdownMenuButton">
-                <li><%= link_to "Newest", public_views_public_staff_index_path(sort_by: :newest), remote: true, class: 'dropdown-item' %></li>
-                <li><%= link_to "Oldest", public_views_public_staff_index_path(sort_by: :oldest), remote: true, class: 'dropdown-item' %></li>
-                <li><%= link_to "Name", public_views_public_staff_index_path(sort_by: :name), remote: true, class: 'dropdown-item' %></li>
-                <li><%= link_to "Display Order", public_views_public_staff_index_path(sort_by: :display_order), remote: true, class: 'dropdown-item' %></li>
+                <li><%= link_to "Default", public_views_public_staff_index_path(sort_by: :display_order, cohort: cohort), remote: true, class: 'dropdown-item' %></li>
+                <li><%= link_to "Name", public_views_public_staff_index_path(sort_by: :name, cohort: cohort), remote: true, class: 'dropdown-item' %></li>
               </div>
             </div>
             <div id="facilitators">

--- a/app/views/public_views/public_staff/index.js.erb
+++ b/app/views/public_views/public_staff/index.js.erb
@@ -1,0 +1,1 @@
+$('#facilitators').html("<%= escape_javascript(render 'user_roles', locals: { selected_type: 'Facilitators', roles: staff[:facilitators] }) %>");


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
Used AJAX to sort the facilitators base on time created, name and display order.

## Screenshots


#### Before:
<img width="948" alt="hey" src="https://user-images.githubusercontent.com/45935526/75157506-39aea080-574f-11ea-8b42-fe8567c8a49c.png">

#### After:
<img width="922" alt="Screenshot 2020-02-21 at 11 42 22 PM" src="https://user-images.githubusercontent.com/45935526/75157519-403d1800-574f-11ea-8e30-dec8dce6e667.png">
