### PR TITLE
Project-level-swap status now doesn't affect admins

### DIFF
--- a/app/views/teams/_team_form.html.erb
+++ b/app/views/teams/_team_form.html.erb
@@ -2,7 +2,7 @@
                     url: {action: (locals[:is_new] ? 'create' : 'update')}) do |f| %>
   <%= f.error_notification %>
   <%= f.input :team_name %>
-  <% if current_user_admin? %>
+  <% if locals[:is_new] %>
     <%= f.input :project_level, collection: {Vostok: 'Vostok',
                                             'Project Gemini'.to_sym => 'Project Gemini',
                                             'Apollo 11'.to_sym => 'Apollo 11'},

--- a/app/views/teams/_team_form.html.erb
+++ b/app/views/teams/_team_form.html.erb
@@ -2,7 +2,13 @@
                     url: {action: (locals[:is_new] ? 'create' : 'update')}) do |f| %>
   <%= f.error_notification %>
   <%= f.input :team_name %>
-  <% if is_project_level_locked? %>
+  <% if current_user_admin? %>
+    <%= f.input :project_level, collection: {Vostok: 'Vostok',
+                                            'Project Gemini'.to_sym => 'Project Gemini',
+                                            'Apollo 11'.to_sym => 'Apollo 11'},
+                                selected: locals[:team].get_project_level,
+                                include_blank: false, required: true %>
+  <% elsif is_project_level_locked? %>
     <div class="form-group string required team_team_name">
       <label class="string required col-sm-3 control-label"> Project level </label>
       <div class="col-sm-9">


### PR DESCRIPTION
Now admin can edit the project levels at ease.

Will further work into updated info by Dr. Zhao: "Perhaps it also make sense for the swap status to lock the editing even for the admins. But the lock should definitely not affect the team creation."

For details please refer to:
https://github.com/nusskylab/nusskylab/pull/784