### PR TITLE
Updates to Registration Script - Ignore duplicate users

### DIFF
--- a/registration/extractData.rb
+++ b/registration/extractData.rb
@@ -3,6 +3,7 @@
 require 'rubygems'
 require 'roo'
 
+REGFILE = 'Orbital Registration (Responses).xlsx'
 PROCESSEDFILE = 'PROCESSED.xlsx'
 SQLFILE = 'sql.txt'
 $teamid = 2500
@@ -75,9 +76,11 @@ def sqlCreator(teamInfo)
 end
 
 def createInsertIntoUsers(userName, nusnetId, matricNo)
-    stmt = "INSERT INTO users (uid, email, user_name, matric_number, provider) VALUES (\'https://openid.nus.edu.sg/"
+    stmt = "INSERT INTO users (uid, email, user_name, matric_number, provider) SELECT \'https://openid.nus.edu.sg/"
     stmt += nusnetId.to_s
-    stmt += ("\', \'" + nusnetId.to_s + "@u.nus.edu', \'" + userName.to_s + "\', \'" + matricNo.to_s + "\', 1);")
+    stmt += ("\', \'" + nusnetId.to_s + "@u.nus.edu', \'" + userName.to_s + "\', \'" + matricNo.to_s + "\', 1 WHERE NOT EXISTS (SELECT * FROM users WHERE matric_number = \'")
+    stmt += matricNo.to_s
+    stmt += "\');"
     return stmt
 end
 
@@ -90,11 +93,14 @@ end
 
 def createInsertIntoStudent(matricNo)
     stmt = "INSERT INTO students (user_id, created_at, updated_at, team_id, cohort) SELECT cast(id as integer), current_timestamp, current_timestamp," + $teamid.to_s + " , #{$cohort} FROM users WHERE matric_number = \'"
-    stmt2 = "\';"
+    stmt2 = "\' AND NOT EXISTS (SELECT * FROM students INNER JOIN users ON users.id=students.user_id WHERE users.matric_number = \'"
+    stmt3 = "\');"
     finalStmt = ""
     finalStmt += stmt
     finalStmt += matricNo.to_s
     finalStmt += stmt2
+    finalStmt += matricNo.to_s
+    finalStmt += stmt3
     return finalStmt
 end
 

--- a/registration/extractData.rb
+++ b/registration/extractData.rb
@@ -76,9 +76,9 @@ def sqlCreator(teamInfo)
 end
 
 def createInsertIntoUsers(userName, nusnetId, matricNo)
-    stmt = "INSERT INTO users (uid, email, user_name, matric_number, provider) SELECT \'https://openid.nus.edu.sg/"
+    stmt = "INSERT INTO users (uid, email, user_name, matric_number, created_at, updated_at, provider) SELECT \'https://openid.nus.edu.sg/"
     stmt += nusnetId.to_s
-    stmt += ("\', \'" + nusnetId.to_s + "@u.nus.edu', \'" + userName.to_s + "\', \'" + matricNo.to_s + "\', 1 WHERE NOT EXISTS (SELECT * FROM users WHERE matric_number = \'")
+    stmt += ("\', \'" + nusnetId.to_s + "@u.nus.edu', \'" + userName.to_s + "\', \'" + matricNo.to_s + "\', current_timestamp, current_timestamp, 1 WHERE NOT EXISTS (SELECT * FROM users WHERE matric_number = \'")
     stmt += matricNo.to_s
     stmt += "\');"
     return stmt

--- a/registration/readme.md
+++ b/registration/readme.md
@@ -15,7 +15,7 @@ This file will only be created when the script has run at least once.
 
 ### Notes
 A few assumptions was made during the development of the script
-* The students do not have an account in skylab and the generation of account and insertion into users, teams, students
+* The generation of account (if not created) and insertion into users, teams, students
 * Students are registering orbital for the first time.
 * Students are NUS students with a working nusnet account.
 * The column headers remain unchanged from the sample as the order of columns matter due to repeated headers.


### PR DESCRIPTION
## Status
**READY**

## Migrations
YES

## Description
* Ensure that repeated users with the same matric number will not be inserted into `STUDENTS` table.
* Users that are previously added as students will not be inserted into `STUDENTS` table.
* Add timestamps during creation of users

## Related PRs
List related PRs against other branches: #807, #812, #813, #814 

## Todos
- [x] Tests
- [ ] Documentation

## Deploy Notes
Read readme.md

## Steps to Test or Reproduce
1. To check if all rows are inserted into their respective teams, run this on the DB (Change the 2500 to the respective team.id)
`SELECT teams.id, teams.team_name, users.user_name, users.matric_number FROM teams JOIN students ON teams.id= students.team_id JOIN users ON users.id=students.user_id WHERE teams.id >= 2500;`
Expected: The full list of 400 students with their teams
1. To check the total rows in the newly created teams, run this on the DB (Change the 2500 to the respective team.id)
`SELECT COUNT(*) FROM teams JOIN students ON teams.id= students.team_id JOIN users ON users.id=students.user_id WHERE teams.id >= 2500;`
Expected: 400 rows returned