### PR TITLE
Updates to Registration Script - Edit uniqueness criteria

### DIFF
--- a/registration/extractData.rb
+++ b/registration/extractData.rb
@@ -58,8 +58,8 @@ def sqlCreator(teamInfo)
 	allSqlStmts << (createInsertIntoTeams(teamName, values[6]))    	
 	
 	# create sql for table students
-	allSqlStmts << (createInsertIntoStudent values[2])
-	allSqlStmts << (createInsertIntoStudent values[5])
+	allSqlStmts << (createInsertIntoStudent values[1], values[2])
+	allSqlStmts << (createInsertIntoStudent values[4], values[5])
 	$teamid += 1
     end
 
@@ -78,8 +78,8 @@ end
 def createInsertIntoUsers(userName, nusnetId, matricNo)
     stmt = "INSERT INTO users (uid, email, user_name, matric_number, created_at, updated_at, provider) SELECT \'https://openid.nus.edu.sg/"
     stmt += nusnetId.to_s
-    stmt += ("\', \'" + nusnetId.to_s + "@u.nus.edu', \'" + userName.to_s + "\', \'" + matricNo.to_s + "\', current_timestamp, current_timestamp, 1 WHERE NOT EXISTS (SELECT * FROM users WHERE matric_number = \'")
-    stmt += matricNo.to_s
+    stmt += ("\', \'" + nusnetId.to_s + "@u.nus.edu', \'" + userName.to_s + "\', \'" + matricNo.to_s + "\', current_timestamp, current_timestamp, 1 WHERE NOT EXISTS (SELECT * FROM users WHERE uid = \'https://openid.nus.edu.sg/")
+    stmt += nusnetId.to_s
     stmt += "\');"
     return stmt
 end
@@ -91,15 +91,15 @@ def createInsertIntoTeams(teamName, cohort)
     return stmt
 end
 
-def createInsertIntoStudent(matricNo)
+def createInsertIntoStudent(nusnetId, matricNo)
     stmt = "INSERT INTO students (user_id, created_at, updated_at, team_id, cohort) SELECT cast(id as integer), current_timestamp, current_timestamp," + $teamid.to_s + " , #{$cohort} FROM users WHERE matric_number = \'"
-    stmt2 = "\' AND NOT EXISTS (SELECT * FROM students INNER JOIN users ON users.id=students.user_id WHERE users.matric_number = \'"
+    stmt2 = "\' AND NOT EXISTS (SELECT * FROM students INNER JOIN users ON users.id=students.user_id WHERE users.uid = \'https://openid.nus.edu.sg/"
     stmt3 = "\');"
     finalStmt = ""
     finalStmt += stmt
     finalStmt += matricNo.to_s
     finalStmt += stmt2
-    finalStmt += matricNo.to_s
+    finalStmt += nusnetId.to_s
     finalStmt += stmt3
     return finalStmt
 end


### PR DESCRIPTION
## Status
**READY**

## Migrations
YES

## Description
* Ensure that repeated users with the same opennet number will not be inserted into `STUDENTS` table.
* Users that are previously added as students will not be inserted into `STUDENTS` table.

## Related PRs
List related PRs against other branches: #807, #812, #813, #814, #815 

## Todos
- [x] Tests
- [ ] Documentation

## Deploy Notes
Read readme.md

## Steps to Test or Reproduce
1. To check if all rows are inserted into their respective teams, run this on the DB (Change the 2500 to the respective team.id)
`SELECT teams.id, teams.team_name, users.user_name, users.matric_number FROM teams JOIN students ON teams.id= students.team_id JOIN users ON users.id=students.user_id WHERE teams.id >= 2500;`
Expected: The full list of 400 students with their teams
1. To check the total rows in the newly created teams, run this on the DB (Change the 2500 to the respective team.id)
`SELECT COUNT(*) FROM teams JOIN students ON teams.id= students.team_id JOIN users ON users.id=students.user_id WHERE teams.id >= 2500;`
Expected: 400 rows returned