### PR TITLE
Updates to Registration Script -  Update student insertion

### DIFF
--- a/registration/extractData.rb
+++ b/registration/extractData.rb
@@ -92,13 +92,10 @@ def createInsertIntoTeams(teamName, cohort)
 end
 
 def createInsertIntoStudent(nusnetId, matricNo)
-    stmt = "INSERT INTO students (user_id, created_at, updated_at, team_id, cohort) SELECT cast(id as integer), current_timestamp, current_timestamp," + $teamid.to_s + " , #{$cohort} FROM users WHERE matric_number = \'"
-    stmt2 = "\' AND NOT EXISTS (SELECT * FROM students INNER JOIN users ON users.id=students.user_id WHERE users.uid = \'https://openid.nus.edu.sg/"
-    stmt3 = "\');"
+    stmt = "INSERT INTO students (user_id, created_at, updated_at, team_id, cohort) SELECT cast(id as integer), current_timestamp, current_timestamp," + $teamid.to_s + " , #{$cohort} FROM users WHERE uid = \'https://openid.nus.edu.sg/"
+    stmt3 = "\';"
     finalStmt = ""
     finalStmt += stmt
-    finalStmt += matricNo.to_s
-    finalStmt += stmt2
     finalStmt += nusnetId.to_s
     finalStmt += stmt3
     return finalStmt

--- a/registration/extractData.rb
+++ b/registration/extractData.rb
@@ -113,7 +113,7 @@ def createUpdateTeamWithAdvisor(teamName, adviserName, achievementLevel)
     stmt += adviserName.to_s
     stmt += "%'), project_level = "
     stmt += levelNum.to_s
-    stmt += " WHERE team_name = '"
+    stmt += " WHERE cohort = #{$cohort} AND team_name = '"
     stmt += teamName.to_s.gsub(/'/){ "\''" }
     stmt += "';" 
 end


### PR DESCRIPTION
## Status
**READY**

## Migrations
YES

## Description
* Ensure that repeated users with the same opennet number will not be inserted into `STUDENTS` table.
* Users that are previously added as students will not be inserted into `STUDENTS` table.

## Related PRs
List related PRs against other branches: #807, #812, #813, #814, #815, #816  

## Todos
- [x] Tests
- [ ] Documentation

## Deploy Notes
Read readme.md

## Steps to Test or Reproduce
1. To check if all rows are inserted into their respective teams, run this on the DB (Change the 2500 to the respective team.id)
`SELECT teams.id, teams.team_name, users.user_name, users.matric_number FROM teams JOIN students ON teams.id= students.team_id JOIN users ON users.id=students.user_id WHERE teams.id >= 2500;`
Expected: The full list of 400 students with their teams
1. To check the total rows in the newly created teams, run this on the DB (Change the 2500 to the respective team.id)
`SELECT COUNT(*) FROM teams JOIN students ON teams.id= students.team_id JOIN users ON users.id=students.user_id WHERE teams.id >= 2500;`
Expected: 400 rows returned