### PR TITLE
Allow teams to update video link

### DIFF
--- a/app/views/teams/_team_basic_info.html.erb
+++ b/app/views/teams/_team_basic_info.html.erb
@@ -73,8 +73,8 @@
   </div>
   <div class="col-sm-12">
     <p class="col-sm-3 col-sm-offset-2">Poster link:</p>
-    <p class="col-sm-7">
-      <a href="<%=locals[:team].poster_link%>">
+    <p class="col-sm-7 text-break">
+      <a href="<%=locals[:team].poster_link%>" style="word-wrap: break-word; width: 100%;">
         <%= locals[:team].poster_link ? locals[:team].poster_link : 'Nil' %>
       </a>
     </p>
@@ -82,7 +82,7 @@
   <div class="col-sm-12">
     <p class="col-sm-3 col-sm-offset-2">Video link:</p>
     <p class="col-sm-7">
-      <a href="<%=locals[:team].video_link%>">
+      <a href="<%=locals[:team].video_link%>" style="word-wrap: break-word; width: 100%;">
         <%= locals[:team].video_link ? locals[:team].video_link : 'Nil' %>
       </a>
     </p>

--- a/app/views/teams/_team_form.html.erb
+++ b/app/views/teams/_team_form.html.erb
@@ -30,9 +30,9 @@
   <% end %>
   <% if current_user_admin? or current_user_adviser? or current_user_student? %>
     <%= f.input :poster_link, placeholder: true, placeholder: 'Enter in url form e.g. https//...' %>
+    <%= f.input :video_link, placeholder: true, placeholder: 'Enter in url form e.g. https//...' %>
   <% end %>
   <% if current_user_admin? or current_user_adviser? %>
-    <%= f.input :video_link, placeholder: true, placeholder: 'Enter in url form e.g. https//...' %>
     <%= f.input :status, collection: {'No Status'.to_sym => 0, 'Contactable and doing well'.to_sym => 1, 'Contactable but lack of progress'.to_sym => 2,
                                       Uncontactable: 3, 'To be re-evaluated': 4},
                                       selected: locals[:team].status,

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -4,7 +4,7 @@ Devise.setup do |config|
   # The secret key used by Devise. Devise uses this key to generate
   # random tokens. Changing this key will render invalid all existing
   # confirmation, reset password and unlock tokens in the database.
-  config.secret_key = '9134be314f6beb15b8515fffd97cd116d267f4e0fe32aa7b1f427553b2e5b84ca4f52e71966c9a51ce4e7ff51c2e92fb33d1b2e25830ad1a90f039b14a60c276'
+  config.secret_key = ENV['DEVISE_SECRET_TOKEN']
   # ==> Mailer Configuration
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -4,7 +4,7 @@ Devise.setup do |config|
   # The secret key used by Devise. Devise uses this key to generate
   # random tokens. Changing this key will render invalid all existing
   # confirmation, reset password and unlock tokens in the database.
-  config.secret_key = ENV['DEVISE_SECRET_TOKEN']
+  config.secret_key = '9134be314f6beb15b8515fffd97cd116d267f4e0fe32aa7b1f427553b2e5b84ca4f52e71966c9a51ce4e7ff51c2e92fb33d1b2e25830ad1a90f039b14a60c276'
   # ==> Mailer Configuration
   # Configure the e-mail address which will be shown in Devise::Mailer,
   # note that it will be overwritten if you use your own mailer class


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
Allow teams to update video link themselves. Fixed overflow problem if the link is too long. 

## Screenshots

#### Before:
Only poster link
<img width="1280" alt="form_before" src="https://user-images.githubusercontent.com/45935526/81267772-91d02000-9079-11ea-9dbf-0bccf84c5bc2.png">

No wrap
<img width="1280" alt="no_wrap" src="https://user-images.githubusercontent.com/45935526/81267776-94327a00-9079-11ea-8c9c-ab754859196e.png">

#### After:
Include video field
<img width="1280" alt="form_after" src="https://user-images.githubusercontent.com/45935526/81267800-9e547880-9079-11ea-8c96-bfc552e8fdda.png">

Text wrap
<img width="1280" alt="wrap" src="https://user-images.githubusercontent.com/45935526/81267807-a0b6d280-9079-11ea-8b8b-b9cca44f9a0f.png">
