### PR TITLE
Update gem for jquery

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -36,7 +36,7 @@ source 'https://rubygems.org' do
   gem 'bootstrap-sass', '~> 3.4.1'
 	gem 'bootstrap-select-rails'
   # Use jquery as the JavaScript library
-  gem 'jquery-rails', '~> 4.2.1'
+  gem 'jquery-rails', '~> 4.4.0'
   # simple_form for form validation
   gem 'simple_form', '~> 3.1.1'
   # tiny_mce for rails

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -59,7 +59,7 @@ GEM
     bootstrap-select-rails (1.13.8)
     bootstrap3-datetimepicker-rails (4.15.35)
       momentjs-rails (>= 2.8.1)
-    builder (3.2.3)
+    builder (3.2.4)
     capybara (2.5.0)
       mime-types (>= 1.16)
       nokogiri (>= 1.3.3)
@@ -81,7 +81,7 @@ GEM
       execjs
     coffee-script-source (1.12.2)
     concurrent-ruby (1.1.6)
-    crass (1.0.5)
+    crass (1.0.6)
     database_cleaner (1.5.3)
     db_text_search (0.2.2)
       activerecord (>= 4.1.15, < 6.0)
@@ -126,7 +126,7 @@ GEM
     jbuilder (2.7.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
-    jquery-rails (4.2.2)
+    jquery-rails (4.4.0)
       rails-dom-testing (>= 1, < 3)
       railties (>= 4.2.0)
       thor (>= 0.14, < 2.0)
@@ -144,7 +144,7 @@ GEM
       kaminari-core (= 1.1.1)
     kaminari-core (1.1.1)
     kramdown (1.17.0)
-    loofah (2.3.1)
+    loofah (2.5.0)
       crass (~> 1.0.2)
       nokogiri (>= 1.5.9)
     mail (2.7.0)
@@ -154,7 +154,7 @@ GEM
     mime-types-data (3.2016.0521)
     mini_mime (1.0.0)
     mini_portile2 (2.4.0)
-    minitest (5.11.3)
+    minitest (5.14.1)
     momentjs-rails (2.20.1)
       railties (>= 3.1)
     multi_json (1.13.1)
@@ -202,8 +202,8 @@ GEM
       activesupport (>= 4.2.0, < 5.0)
       nokogiri (~> 1.6)
       rails-deprecated_sanitizer (>= 1.0.1)
-    rails-html-sanitizer (1.0.4)
-      loofah (~> 2.2, >= 2.2.2)
+    rails-html-sanitizer (1.3.0)
+      loofah (~> 2.3)
     rails-i18n (4.0.9)
       i18n (~> 0.7)
       railties (~> 4.0)
@@ -299,7 +299,7 @@ GEM
       actionpack (>= 4.0)
       activesupport (>= 4.0)
       sprockets (>= 3.0.0)
-    thor (0.20.0)
+    thor (0.20.3)
     thread_safe (0.3.6)
     thredded (0.9.4)
       active_record_union (>= 1.2.0)
@@ -331,7 +331,7 @@ GEM
       railties (>= 3.1.1)
     turbolinks (2.5.4)
       coffee-rails
-    tzinfo (1.2.5)
+    tzinfo (1.2.7)
       thread_safe (~> 0.1)
     uglifier (4.1.11)
       execjs (>= 0.3.0, < 3)
@@ -363,7 +363,7 @@ DEPENDENCIES
   factory_girl_rails (~> 4.5.0)!
   gravtastic (~> 3.2.6)!
   jbuilder (~> 2.0)!
-  jquery-rails (~> 4.2.1)!
+  jquery-rails (~> 4.4.0)!
   momentjs-rails (>= 2.9.0)!
   omniauth (~> 1.6.1)!
   omniauth-openid (~> 1.0.1)!
@@ -390,4 +390,4 @@ DEPENDENCIES
   web-console (~> 2.0)!
 
 BUNDLED WITH
-   1.16.2
+   1.17.2


### PR DESCRIPTION
## Status
**READY/IN DEVELOPMENT/HOLD**

## Migrations
YES | NO

## Description
This commit updates the jQuery version to 3.5.1 by updating the gem jquery-rails to 4.4.0.

## Screenshots
Add screenshots to [summarize the UI changes (if any)](https://github.com/nusskylab/nusskylab/pull/692#pullrequestreview-236562760)

#### Before:
Add screenshot showing the current state of Skylab (in sync with the master branch)

#### After:
Add screenshot showing the UI changes made by your PR

 
## Related PRs
List related PRs against other branches:

## Todos
- [ ] Tests
- [ ] Documentation


## Deploy Notes
Notes regarding deployment the contained body of work.  These should note any
db migrations, etc.

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

## Fixes

* 
