### PR TITLE
Project gallery: let posters open in new tab

### DIFF
--- a/app/views/public_views/public_projects/_public_teams_table.html.erb
+++ b/app/views/public_views/public_projects/_public_teams_table.html.erb
@@ -35,7 +35,7 @@
     <a role="button" onclick="createModalBox(<%= team.team_name %>)" id="button_<%= team.team_name %>">
       <% if !team.poster_link.blank? %>
         <%= link_to image_tag(team.poster_link, size: "200", alt: "Team's Poster Link is not in image form",
-          title: "Click to view an enlarged version of this image.", id: "img_#{team.team_name}", onerror: "onerror=null;replaceImg(this, '#{team.project_level}')"), team.poster_link %>
+          title: "Click to view an enlarged version of this image.", id: "img_#{team.team_name}", onerror: "onerror=null;replaceImg(this, '#{team.project_level}')"), team.poster_link, target: :_blank, rel: 'noopener noreferrer' %>
       <% elsif locals[:selected_type] == 'Vostok' %>
         <%= image_tag("Vostok_Icon.jpg", size: "200", class: 'img-rounded inactive_link') %>
       <% elsif locals[:selected_type] == 'Project Gemini' %>
@@ -75,7 +75,7 @@
       <% if not submissions.length == 0 %>
         <% if not submissions[-1].video_link.blank? %>
           <div class="col-md-6">
-            <a role="button" class="button button_video" href="<%= submissions[-1].video_link %>">
+            <a role="button" class="button button_video" href="<%= submissions[-1].video_link %>"  target="_blank" rel="noopener noreferrer">
               Watch Project Video
             </a>
           </div>
@@ -84,7 +84,7 @@
         <% end %>
         <% if not submissions[-1].poster_link.blank? %>
           <div class="col-md-6">
-            <a role="button" class="button button_video" href="<%= submissions[-1].poster_link %>">
+            <a role="button" class="button button_video" href="<%= submissions[-1].poster_link %>"  target="_blank" rel="noopener noreferrer">
               View Project Poster
             </a>
           </div>


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
Allows posters in the project gallery to automatically open in a new tab

#### Before:
Posters open in the same tab

#### After:
Posters open in a new tab

## Fixes

* #840 
