### PR TITLE
Conditionally display Artemis tab in project gallery for cohorts after 2020

### DIFF
--- a/app/views/public_views/public_projects/index.html.erb
+++ b/app/views/public_views/public_projects/index.html.erb
@@ -17,7 +17,10 @@
 			<li><a data-toggle="pill" href="#vostok<%=cohort%>">Vostok</a></li>
 			<li><a data-toggle="pill" href="#project_gemini<%=cohort%>">Project Gemini</a></li>
 			<li><a data-toggle="pill" href="#apollo_11<%=cohort%>">Apollo 11</a></li>
-			<li class="active"><a data-toggle="pill" href="#artemis<%=cohort%>">Artemis</a></li>
+      <!-- Artemis only introduced in cohort 2020 -->
+      <% if cohort >= 2020 %>
+			  <li class="active"><a data-toggle="pill" href="#artemis<%=cohort%>">Artemis</a></li>
+      <% end %>
 		</ul>
 		<div class="tab-content">
 			<div id="vostok<%=cohort%>" class="tab-pane fade">
@@ -47,15 +50,15 @@
 					No Data Available
 				<% end %>
 			</div>
-			<div id="artemis<%=cohort%>" class="tab-pane fade in active">
-				<% if teams.select{|team| team.artemis?}.length > 0 %>
-					<%= render 'public_teams_table', locals: {teams: teams,
-						selected_teams: teams.select{|team| team.artemis?},
-						selected_type: 'Artemis'} %>
-				<% else %>
-					No Data Available
-				<% end %>
-			</div>
+      <div id="artemis<%=cohort%>" class="tab-pane fade in active">
+        <% if teams.select{|team| team.artemis?}.length > 0 %>
+          <%= render 'public_teams_table', locals: {teams: teams,
+            selected_teams: teams.select{|team| team.artemis?},
+            selected_type: 'Artemis'} %>
+        <% else %>
+          No Data Available
+        <% end %>
+      </div>
 		</div>
 	</div>
 <% end %>


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
Artemis was only introduced in 2020. The 'Artemis' tab in the project gallery should hence be hidden for cohorts before 2020.

## Screenshots
#### Before:
Current Cohort 2019 (Artemis tab appears)
![image](https://user-images.githubusercontent.com/48963238/106627515-d8748b80-65b3-11eb-9a34-b8b683206325.png)

#### After:
New Cohort 2019 (Artemis tab hidden)
![image](https://user-images.githubusercontent.com/48963238/106627227-8c294b80-65b3-11eb-987d-3843ce770c1a.png)

New Cohort 2021 (unchanged)
![image](https://user-images.githubusercontent.com/48963238/106627340-ac590a80-65b3-11eb-9e5e-db767c97d0a7.png)


## Fixes
- Resolves #838 
