### PR TITLE
Highlight cohort tab under project gallery upon fresh reload

### DIFF
--- a/app/views/public_views/public_projects/index.html.erb
+++ b/app/views/public_views/public_projects/index.html.erb
@@ -2,8 +2,8 @@
 <% first_loop = true; %>
 <ul class="nav nav-pills nav-stacked col-md-2" id="all_cohorts">
 	<% @teams_table.each do | cohort, teams | %>
-	<li>
-		<a role="button" data-toggle="pill" href="#<%=cohort%>" class="<% if first_loop %>active<% first_loop = false; end %>">
+	<li class="<% if first_loop and cohort == current_cohort%>active<% first_loop = false; end %>">
+		<a role="button" data-toggle="pill" href="#<%=cohort%>">
 			Cohort <%= cohort %>
 		</a>
 	</li>


### PR DESCRIPTION
## Status
**READY*

## Migrations
NO

## Description
Fix the error where the cohort tab in the project gallery is not automatically highlighted  upon fresh reload

## Screenshots when fresh reload

#### Before:
![image](https://user-images.githubusercontent.com/58925632/106728759-baf10180-6647-11eb-95fd-bb111ce6a182.png)


#### After:
![image](https://user-images.githubusercontent.com/58925632/106728854-d6f4a300-6647-11eb-9703-70989e3f683c.png)

## Fixes

* Close #851 
