### PR TITLE
Remove openid signup button

### DIFF
--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -28,6 +28,3 @@
   <% end -%>
 <% end -%>
 <br><hr>
-<div class="col-sm-8 col-sm-offset-4">
-  Or you can <%= link_to 'Sign in with NUS',  nus_openid_login_path, class: 'btn btn-info' %>
-</div>


### PR DESCRIPTION
## Status
**READY**

## Migrations
YES

## Description
Since NUS retired OpenID in May, the signup By OpenID button should be removed.

## Screenshots
Add screenshots to [summarize the UI changes (if any)](https://github.com/nusskylab/nusskylab/pull/692#pullrequestreview-236562760)

#### Before:
![image](https://user-images.githubusercontent.com/48383749/125521503-f1cac2ea-653d-4803-8278-d1502b9bf4c1.png)



#### After:
![image](https://user-images.githubusercontent.com/48383749/125521387-1a61a7b1-42d3-4fb7-8498-2a2c6a76fc2d.png)


 
## Related PRs
List related PRs against other branches:

## Todos
- [x] Tests
- [x] Documentation


## Deploy Notes
Notes regarding deployment the contained body of work.  These should note any
db migrations, etc.

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

## Fixes

* 
