### PR TITLE
Fix noMethodError when advisers edit teams

### DIFF
--- a/app/models/team.rb
+++ b/app/models/team.rb
@@ -131,10 +131,6 @@ class Team < ActiveRecord::Base
     project_level.gsub(/_/, ' ').split(' ').map(&:capitalize).join(' ')
   end
 
-  def is_artemis?
-    self.get_project_level == "Artemis"
-  end
-
   def get_relevant_users(include_evaluator = false, include_evaluated = false)
     relevant_users = get_team_members
     relevant_users.append(adviser.user) unless adviser_id.blank?

--- a/app/views/teams/_team_form.html.erb
+++ b/app/views/teams/_team_form.html.erb
@@ -10,7 +10,7 @@
                                             'Artemis'.to_sym => 'Artemis'},
                                 selected: locals[:team].get_project_level,
                                 include_blank: false, required: true %>
-  <% elsif !is_project_level_locked? && current_user_adviser? && !locals[:team].is_artemis? %>
+  <% elsif !is_project_level_locked? && current_user_adviser? && !locals[:team].artemis? %>
     <%= f.input :project_level, collection: {Vostok: 'Vostok',
                                             'Project Gemini'.to_sym => 'Project Gemini',
                                             'Apollo 11'.to_sym => 'Apollo 11'},


### PR DESCRIPTION
## Status
**READY**

## Migrations
NO

## Description
Fixed noMethodError when advisers edit teams

## Screenshots
#### Before:
![1](https://user-images.githubusercontent.com/69447105/152272447-68827edb-4f95-4e39-8a7e-b08b6bfca10d.PNG)

#### After:
Add screenshot showing the UI changes made by your PR

## Related PRs
List related PRs against other branches:

## Todos
- [ ] Tests
- [ ] Documentation


## Deploy Notes
Notes regarding deployment the contained body of work.  These should note any
db migrations, etc.

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

## Fixes
* 
