### PR TITLE
Dashboard redesign

### DIFF
--- a/app/views/admins/_admin_view.html.erb
+++ b/app/views/admins/_admin_view.html.erb
@@ -10,7 +10,7 @@
         <li role="presentation" class="active">
           <a href="#user-details" aria-controls="user-details"
              role="tab" data-toggle="tab">
-            User details
+            User Details
           </a>
         </li>
         <li role="presentation">

--- a/app/views/admins/_admin_view.html.erb
+++ b/app/views/admins/_admin_view.html.erb
@@ -24,7 +24,6 @@
     <div class="tab-content">
       <div role="tabpanel" class="tab-pane fade in active" id="user-details">
         <div class="col-sm-12">
-          <div class="well">You can use navbar above to look around</div>
           <%= render 'users/user_details', locals: {user: locals[:admin].user} %>
           <br>
           <hr>

--- a/app/views/advisers/_adviser_view.html.erb
+++ b/app/views/advisers/_adviser_view.html.erb
@@ -8,6 +8,12 @@
       <div role="tabpanel">
         <ul class="nav nav-tabs" role="tablist">
           <li role="presentation" class="active">
+            <a href="#user-details" aria-controls="user-details"
+              role="tab" data-toggle="tab">
+              User Details
+            </a>
+          </li>
+          <li role="presentation">
             <a href="#teams-panel" aria-controls="teams-panel"
                role="tab" data-toggle="tab">
               View all your teams
@@ -27,7 +33,12 @@
           </li>
         </ul>
         <div class="tab-content">
-          <div role="tabpanel" class="tab-pane fade in active" id="teams-panel">
+          <div role="tabpanel" class="tab-pane fade in active" id="user-details">
+            <div class="col-sm-12">
+              <%= render 'users/user_details', locals: {user: locals[:adviser].user} %>
+            </div>
+          </div>
+          <div role="tabpanel" class="tab-pane fade" id="teams-panel">
             <h2 class="text-center">Teams</h2>
             <div class="well">
               <p class="small"><%= t '.view_teams_instruction' %></p>

--- a/app/views/advisers/_adviser_view.html.erb
+++ b/app/views/advisers/_adviser_view.html.erb
@@ -1,0 +1,67 @@
+<div class="panel panel-default">
+    <div class="panel-heading">
+      <h2>
+        <span>Hi, <%= @role.user.user_name %> </span>
+      </h2>
+    </div>
+    <div class="panel-body">
+      <div role="tabpanel">
+        <ul class="nav nav-tabs" role="tablist">
+          <li role="presentation" class="active">
+            <a href="#teams-panel" aria-controls="teams-panel"
+               role="tab" data-toggle="tab">
+              View all your teams
+            </a>
+          </li>
+          <li role="presentation">
+            <a href="#evaluations-panel" aria-controls="evaluations-panel"
+               role="tab" data-toggle="tab">
+              Submit evaluations
+            </a>
+          </li>
+          <li role="presentation">
+            <a href="#evaluatings-panel" aria-controls="evaluatings-panel"
+               role="tab" data-toggle="tab">
+              View more info
+            </a>
+          </li>
+        </ul>
+        <div class="tab-content">
+          <div role="tabpanel" class="tab-pane fade in active" id="teams-panel">
+            <h2 class="text-center">Teams</h2>
+            <div class="well">
+              <p class="small"><%= t '.view_teams_instruction' %></p>
+            </div>
+            <%= render 'adviser_teams', locals: { adviser: @role, milestones: locals[:milestones]} %>
+          </div>
+          <div role="tabpanel" class="tab-pane fade" id="evaluations-panel">
+            <h2 class="text-center">Evaluations</h2>
+            <div class="well">
+              <p class="small"><%= t '.evaluation_instruction' %></p>
+            </div>
+            <%= render 'adviser_milestones', locals: {
+              adviser: @role,
+              milestones: locals[:milestones],
+              teams_submissions: locals[:teams_submissions],
+              own_evaluations: locals[:own_evaluations]
+            } %>
+          </div>
+          <div role="tabpanel" class="tab-pane fade" id="evaluatings-panel">
+            <h2 class="text-center">More info</h2>
+            <div class="well">
+              <p class="small"><%= t '.more_info_instruction' %></p>
+            </div>
+            <hr>
+            <div class="text-center">
+              You can view feedbacks for you
+              <a href="<%= milestone_adviser_received_feedbacks_path(3, @role.id) %>"
+                 class="btn btn-success">here</a>
+              <br><hr>
+              You can send emails to your students via
+              <%= link_to 'General Mailing', general_mailing_adviser_path(@role.id), class: 'btn btn-success' %>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>

--- a/app/views/advisers/show.html.erb
+++ b/app/views/advisers/show.html.erb
@@ -1,70 +1,10 @@
 <% content_for :main_content do %>
   <% javascript 'advisers.js' %>
-  <div class="panel panel-default">
-    <div class="panel-heading">
-      <h2>
-        <span><%= @role.user.user_name %> </span>
-      </h2>
-    </div>
-    <div class="panel-body">
-      <div role="tabpanel">
-        <ul class="nav nav-tabs" role="tablist">
-          <li role="presentation" class="active">
-            <a href="#teams-panel" aria-controls="teams-panel"
-               role="tab" data-toggle="tab">
-              View all your teams
-            </a>
-          </li>
-          <li role="presentation">
-            <a href="#evaluations-panel" aria-controls="evaluations-panel"
-               role="tab" data-toggle="tab">
-              Submit evaluations
-            </a>
-          </li>
-          <li role="presentation">
-            <a href="#evaluatings-panel" aria-controls="evaluatings-panel"
-               role="tab" data-toggle="tab">
-              View more info
-            </a>
-          </li>
-        </ul>
-        <div class="tab-content">
-          <div role="tabpanel" class="tab-pane fade in active" id="teams-panel">
-            <h2 class="text-center">Teams</h2>
-            <div class="well">
-              <p class="small"><%= t '.view_teams_instruction' %></p>
-            </div>
-            <%= render 'adviser_teams', locals: { adviser: @role, milestones: role_data[:milestones]} %>
-          </div>
-          <div role="tabpanel" class="tab-pane fade" id="evaluations-panel">
-            <h2 class="text-center">Evaluations</h2>
-            <div class="well">
-              <p class="small"><%= t '.evaluation_instruction' %></p>
-            </div>
-            <%= render 'adviser_milestones', locals: {
-              adviser: @role,
-              milestones: role_data[:milestones],
-              teams_submissions: role_data[:teams_submissions],
-              own_evaluations: role_data[:own_evaluations]
-            } %>
-          </div>
-          <div role="tabpanel" class="tab-pane fade" id="evaluatings-panel">
-            <h2 class="text-center">More info</h2>
-            <div class="well">
-              <p class="small"><%= t '.more_info_instruction' %></p>
-            </div>
-            <hr>
-            <div class="text-center">
-              You can view feedbacks for you
-              <a href="<%= milestone_adviser_received_feedbacks_path(3, @role.id) %>"
-                 class="btn btn-success">here</a>
-              <br><hr>
-              You can send emails to your students via
-              <%= link_to 'General Mailing', general_mailing_adviser_path(@role.id), class: 'btn btn-success' %>
-            </div>
-          </div>
-        </div>
-      </div>
-    </div>
-  </div>
+  <%= render 'adviser_view', locals: {
+    adviser: @role,
+    milestones: role_data[:milestones],
+    teams_submissions: role_data[:teams_submissions],
+    own_evaluations: role_data[:own_evaluations],
+    role_data: role_data
+  } %>
 <% end %>

--- a/app/views/mentors/_mentor_view.html.erb
+++ b/app/views/mentors/_mentor_view.html.erb
@@ -8,6 +8,12 @@
     <div role="tabpanel">
       <ul class="nav nav-tabs" role="tablist">
         <li role="presentation" class="active">
+          <a href="#user-details" aria-controls="user-details"
+            role="tab" data-toggle="tab">
+            User Details
+          </a>
+        </li>
+        <li role="presentation">
           <a href="#teams-panel" aria-controls="teams-panel"
              role="tab" data-toggle="tab">
             View all your teams
@@ -29,7 +35,12 @@
         <% end %>
       </ul>
       <div class="tab-content">
-        <div role="tabpanel" class="tab-pane fade in active" id="teams-panel">
+        <div role="tabpanel" class="tab-pane fade in active" id="user-details">
+          <div class="col-sm-12">
+            <%= render 'users/user_details', locals: {user: locals[:mentor].user} %>
+          </div>
+        </div>
+        <div role="tabpanel" class="tab-pane fade" id="teams-panel">
           <h2 class="text-center">Teams</h2>
           <%= render 'mentors_teams', locals: {mentor: @role} %>
           <hr/>

--- a/app/views/public_views/public_projects/index.html.erb
+++ b/app/views/public_views/public_projects/index.html.erb
@@ -50,15 +50,15 @@
 					No Data Available
 				<% end %>
 			</div>
-      <div id="artemis<%=cohort%>" class="tab-pane fade in active">
-        <% if teams.select{|team| team.artemis?}.length > 0 %>
-          <%= render 'public_teams_table', locals: {teams: teams,
-            selected_teams: teams.select{|team| team.artemis?},
-            selected_type: 'Artemis'} %>
-        <% else %>
-          No Data Available
-        <% end %>
-      </div>
+			<div id="artemis<%=cohort%>" class="tab-pane fade in active">
+				<% if teams.select{|team| team.artemis?}.length > 0 %>
+				<%= render 'public_teams_table', locals: {teams: teams,
+					selected_teams: teams.select{|team| team.artemis?},
+					selected_type: 'Artemis'} %>
+				<% else %>
+				No Data Available
+				<% end %>
+			</div>
 		</div>
 	</div>
 <% end %>

--- a/app/views/students/_student_with_team.html.erb
+++ b/app/views/students/_student_with_team.html.erb
@@ -12,6 +12,12 @@
     <div role="tabpanel">
       <ul class="nav nav-tabs" role="tablist">
         <li role="presentation" class="active">
+          <a href="#user-details" aria-controls="user-details"
+            role="tab" data-toggle="tab">
+            User Details
+          </a>
+        </li>
+        <li role="presentation">
           <a href="#project-panel" aria-controls="project-panel"
              role="tab" data-toggle="tab">
             Submit project log
@@ -43,7 +49,12 @@
         </li>
       </ul>
       <div class="tab-content">
-        <div role="tabpanel" class="tab-pane fade in active" id="project-panel">
+        <div role="tabpanel" class="tab-pane fade in active" id="user-details">
+          <div class="col-sm-12">
+            <%= render 'users/user_details', locals: {user: locals[:student].user} %>
+          </div>
+        </div>
+        <div role="tabpanel" class="tab-pane fade" id="project-panel">
           <h2 class="text-center">Submissions</h2>
           <div class="well">
             <p class="small"><%= t '.submit_submission_instruction' %></p>

--- a/app/views/teams/_teams_table.html.erb
+++ b/app/views/teams/_teams_table.html.erb
@@ -17,7 +17,7 @@
         <td class="col-md-1 <%= team.get_team_status_short + '_status' %>", title='<%= team.get_team_status + "\n" %><%= team.get_team_comment %>'>
           <%= team.get_team_status_short %>
         </td>
-        <td class="col-md-1"><%= team.get_team_members[1] == nil ? "": team.get_team_members[0].user_name %></td>
+        <td class="col-md-1"><%= team.get_team_members[0] == nil ? "": team.get_team_members[0].user_name %></td>
         <td class="col-md-1"><%= team.get_team_members[1] == nil ? "": team.get_team_members[1].user_name %></td>
         <td class="col-md-1"><%= team.adviser ? team.adviser.user.user_name : 'Not assigned' %></td>
         <td class="col-md-1"><%= team.mentor ? team.mentor.user.user_name : 'Not assigned' %></td>

--- a/app/views/users/_user_details.html.erb
+++ b/app/views/users/_user_details.html.erb
@@ -22,6 +22,7 @@
       <div>Personal website: <%= auto_link(locals[:user].blog_link) %></div>
       <div>Self Introduction: <%= auto_link(locals[:user].self_introduction) %></div>
       <!-- Role Description -->
+      <!-- TODO: Users role description depend on the role they are using -->
       <% if current_user_admin? %>
         <div class="panel-group" id="accordion">
           <a data-toggle="collapse" data-parent="#accordion" href="#role">Role: Admin</a>

--- a/app/views/users/_user_details.html.erb
+++ b/app/views/users/_user_details.html.erb
@@ -28,7 +28,7 @@
           <div id="role" class="panel-collapse collapse out">
             As an admin, you have authority over all features. 
             You can view/create/edit/delete users, teams, milestones and everything that is available on the navbar above. 
-            In addition, you control registration and project level status under Registration Management.
+            In addition, you can control registration and project level status under Registration Management.
           </div>
         </div>
       <% elsif current_user_adviser? %>

--- a/app/views/users/_user_details.html.erb
+++ b/app/views/users/_user_details.html.erb
@@ -28,7 +28,8 @@
           <div id="role" class="panel-collapse collapse out">
             As an admin, you have authority over all features. 
             You can view/create/edit/delete users, teams, milestones and everything that is available on the navbar above. 
-            In addition, you can control registration and project level status under Registration Management.
+            In addition, you can control registration and project level status under Registration Management, and preview as
+            any user.
           </div>
         </div>
       <% elsif current_user_adviser? %>

--- a/app/views/users/_user_details.html.erb
+++ b/app/views/users/_user_details.html.erb
@@ -8,7 +8,7 @@
   </style>
 </head>
 <div class="panel panel-info">
-  <div class="panel-heading"><h3 class="text-center">User details</h3></div>
+  <div class="panel-heading"><h3 class="text-center">User Details</h3></div>
   <div class="panel-body">
     <div class="row">
     <div class="col-md-3">
@@ -21,6 +21,46 @@
       <div>LinkedIn: <%= auto_link(locals[:user].linkedin_link) %></div>
       <div>Personal website: <%= auto_link(locals[:user].blog_link) %></div>
       <div>Self Introduction: <%= auto_link(locals[:user].self_introduction) %></div>
+      <!-- Role Description -->
+      <% if current_user_admin? %>
+        <div class="panel-group" id="accordion">
+          <a data-toggle="collapse" data-parent="#accordion" href="#role">Role: Admin</a>
+          <div id="role" class="panel-collapse collapse out">
+            As an admin, you have authority over all features. 
+            You can view/create/edit/delete users, teams, milestones and everything that is available on the navbar above. 
+            In addition, you control registration and project level status under Registration Management.
+          </div>
+        </div>
+      <% elsif current_user_adviser? %>
+        <div class="panel-group" id="accordion">
+          <a data-toggle="collapse" data-parent="#accordion" href="#role">Role: Adviser</a>
+          <div id="role" class="panel-collapse collapse out">
+            As an adviser, you can view all students in the cohort, manage evaluation relationships and teams under you, and evaluate your teams.
+          </div>
+        </div>
+      <% elsif current_user_student? %>
+        <div class="panel-group" id="accordion">
+          <a data-toggle="collapse" data-parent="#accordion" href="#role">Role: Student</a>
+          <div id="role" class="panel-collapse collapse out">
+            As a student, you can update your project submissions and peer evaluations, edit your team's name and links, and interact in the forum.
+          </div>
+        </div>
+      <% elsif current_user_mentor? %>
+        <div class="panel-group" id="accordion">
+          <a data-toggle="collapse" data-parent="#accordion" href="#role">Role: Mentor</a>
+          <div id="role" class="panel-collapse collapse out">
+            As a mentor, you can view/edit the details (except for project level) of the teams you are mentoring, as well as matching mentors.
+          </div>
+        </div>
+      <% else %>
+        <div class="panel-group" id="accordion">
+          <a data-toggle="collapse" data-parent="#accordion" href="#role">Role: User</a>
+          <div id="role" class="panel-collapse collapse out">
+            As a user, you can view past orbital projects and staff, and interact in the forum.
+          </div>
+        </div>
+      <% end %>
+      
     </div>
     <div class="col-sm-12"><br><i>You may change your profile picture with <a href="http://www.gravatar.org/">Gravatar</a>.</i></div>
     </div>

--- a/app/views/users/show.html.erb
+++ b/app/views/users/show.html.erb
@@ -43,13 +43,17 @@
                 <% adm, adv, men, stu = user_admin?, user_adviser?, user_mentor?, user_student? %>	
                 <% if adm or adv or men or stu %>	
                 <p>Use Skylab as:</p>	
-                <p>	
-                  <% if adm and adv %>	
-                    <a href="<%= admin_path(adm.id) %>" class="btn btn-primary btn-lg">An Admin</a>	
-                    <a href="<%= adviser_path(adv.id) %>" class="btn btn-primary btn-lg">An Adviser</a>	
-                  <% elsif adm %>	
-                    <a href="<%= admin_path(adm.id) %>" class="btn btn-primary btn-lg">An Admin</a>	
-                  <% elsif adv %>	
+                <p>
+                  <!-- Only admin can take on multiple roles -->
+                  <% if adm %>	
+                    <a href="<%= admin_path(adm.id) %>" class="btn btn-primary btn-lg">An Admin</a>
+                    <% if adv %>
+                      <a href="<%= adviser_path(adv.id) %>" class="btn btn-primary btn-lg">An Adviser</a>	
+                    <% end %>
+                    <% if men %>
+                      <a href="<%= mentor_path(men.id) %>" class="btn btn-primary btn-lg">A Mentor</a>
+                    <% end %>
+                  <% elsif adv %>
                     <a href="<%= adviser_path(adv.id) %>" class="btn btn-primary btn-lg">An Adviser</a>	
                   <% elsif men %>	
                     <a href="<%= mentor_path(men.id) %>" class="btn btn-primary btn-lg">A Mentor</a>	


### PR DESCRIPTION
## Status
**IN DEVELOPMENT**

## Migrations
NO

## Description
Added User Details page to every role.
Allow admin to take on multiple roles instead of only admin + adviser. Only admins can have more than one role.

## Screenshots
#### Before:
Student:
![StudentOLD](https://user-images.githubusercontent.com/69447105/152270265-13ef3761-43a2-47d0-93bb-1ef6131dbd70.PNG)

Mentor:
![MentorOLD](https://user-images.githubusercontent.com/69447105/152270295-12635665-e969-498c-8eaf-dfba71477da8.PNG)

Adviser:
![AdviserOLD](https://user-images.githubusercontent.com/69447105/152270301-0d84a6f2-a59b-465e-a78b-0ffa1c765b1b.PNG)

#### After:
Student:
![StudentNEW](https://user-images.githubusercontent.com/69447105/152270320-2bd6bfd5-0a4b-4365-9349-50387d0cb4f6.PNG)

Mentor:
![MentorNEW](https://user-images.githubusercontent.com/69447105/152270348-7dd2f5b4-9c95-4a33-b96f-5a906b7846a6.PNG)

Adviser:
![AdviserNEW](https://user-images.githubusercontent.com/69447105/152270354-58ee9575-39cd-4b59-82d8-2ce648b0f35a.PNG)

Role Description as collapsible, default is collapsed:
![AdminNEW1](https://user-images.githubusercontent.com/69447105/152270557-62e47cb4-66be-4229-ac9b-5f57c06a5d44.PNG)
![AdminNEW2](https://user-images.githubusercontent.com/69447105/152270577-7ed3e65f-7bb0-4440-bf92-1b8cffefc0e6.PNG)

## Related PRs
List related PRs against other branches:

## Todos
- [ ] Tests
- [ ] Documentation
Currently, when admins have multiple roles, their role description will only display admin even if they use skylab as a different role. Need to change to have the role description display whichever role the admin is using skylab as.

## Deploy Notes
Notes regarding deployment the contained body of work.  These should note any
db migrations, etc.

## Steps to Test or Reproduce
Outline the steps to test or reproduce the PR here.

## Fixes
*
